### PR TITLE
(Fix): Changed cached site id call in repository

### DIFF
--- a/buildSrc/src/main/kotlin/com/mercadopago/sdk/android/BomConfig.kt
+++ b/buildSrc/src/main/kotlin/com/mercadopago/sdk/android/BomConfig.kt
@@ -8,5 +8,5 @@ package com.mercadopago.sdk.android
 object BomConfig {
 
     const val ARTIFACT_ID = "sdk-android-bom"
-    const val VERSION_NAME = "0.0.9"
+    const val VERSION_NAME = "0.1.1"
 }

--- a/buildSrc/src/main/kotlin/com/mercadopago/sdk/android/MercadoPagoSDKConfig.kt
+++ b/buildSrc/src/main/kotlin/com/mercadopago/sdk/android/MercadoPagoSDKConfig.kt
@@ -31,5 +31,5 @@ object MercadoPagoSDKConfig {
     const val ARTIFACT_ID = "sdk-android"
 
     // SDK Android
-    const val VERSION_NAME = "0.0.4"
+    const val VERSION_NAME = "0.1.1"
 }

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/data/remote/utils/Constants.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/data/remote/utils/Constants.kt
@@ -1,6 +1,8 @@
 package com.mercadopago.sdk.android.coremethods.data.remote.utils
 
-internal const val PRODUCT_ID: String = "CVQP49FTT60D1548Q56G"
+import com.mercadopago.sdk.android.coremethods.BuildConfig
+
+internal const val PRODUCT_ID: String = BuildConfig.CORE_METHODS_PRODUCT_ID
 
 internal const val EXPIRATION_YEAR_START = "20"
 internal const val EXPIRATION_YEAR_MIN_LENGTH = 2

--- a/sdk-android/build.gradle.kts
+++ b/sdk-android/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.mercadopago.sdk.android.BomConfig
+import java.io.FileInputStream
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.library)
@@ -37,6 +39,18 @@ android {
         minSdk = MercadoPagoSDKConfig.MIN_SDK
         version = MercadoPagoSDKConfig.VERSION_NAME
         buildConfigField("String", "SdkVersion", "\"${BomConfig.VERSION_NAME}\"")
+
+        val secretPropertiesFile = rootProject.file("secrets.properties")
+        val secretProperties = Properties()
+        runCatching {
+            secretProperties.load(FileInputStream(secretPropertiesFile))
+        }
+
+        buildConfigField(
+            "String",
+            "CORE_METHODS_PRODUCT_ID",
+            secretProperties.getProperty("coreMethods.productId", "\"\""),
+        )
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/sdk-android/src/main/java/com/mercadopago/sdk/android/data/remote/service/SdkInitializationService.kt
+++ b/sdk-android/src/main/java/com/mercadopago/sdk/android/data/remote/service/SdkInitializationService.kt
@@ -1,13 +1,18 @@
 package com.mercadopago.sdk.android.data.remote.service
 
+import com.mercadopago.sdk.android.BuildConfig
 import com.mercadopago.sdk.android.data.remote.response.SiteIdResponse
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 private const val BRICKS_API = "cho-off"
 private const val VERSION = "v1"
+internal const val PRODUCT_ID: String = BuildConfig.CORE_METHODS_PRODUCT_ID
 
 internal interface SdkInitializationService {
 
     @GET("$BRICKS_API/$VERSION/site_id")
-    suspend fun fetchSiteId(): SiteIdResponse
+    suspend fun fetchSiteId(
+        @Query("product_id") productId: String? = PRODUCT_ID,
+    ): SiteIdResponse
 }

--- a/sdk-android/src/main/java/com/mercadopago/sdk/android/data/repository/SdkInitializationRepositoryImpl.kt
+++ b/sdk-android/src/main/java/com/mercadopago/sdk/android/data/repository/SdkInitializationRepositoryImpl.kt
@@ -27,7 +27,7 @@ internal class SdkInitializationRepositoryImpl(
 ) : SdkInitializationRepository {
 
     @OptIn(FlowPreview::class)
-    override fun fetchSiteId(publicKey: String): Flow<SiteId> = flow {
+    override fun fetchSiteId(publicKey: String, countryCode: CountryCode): Flow<SiteId> = flow {
         val cachedSiteId: SiteId = sdkInitializationLocalDataSource.getSiteId(publicKey).first()
 
         if (cachedSiteId.siteId.isNotEmpty()) {
@@ -40,7 +40,8 @@ internal class SdkInitializationRepositoryImpl(
                     .onEach { siteId ->
                         sdkInitializationLocalDataSource.setSiteId(publicKey, siteId)
                     }
-                    .catch { _ ->
+                    .catch { error ->
+                        setSiteId(publicKey, countryCode)
                         emitAll(sdkInitializationLocalDataSource.getSiteId(publicKey))
                     }
             )

--- a/sdk-android/src/main/java/com/mercadopago/sdk/android/data/repository/SdkInitializationRepositoryImpl.kt
+++ b/sdk-android/src/main/java/com/mercadopago/sdk/android/data/repository/SdkInitializationRepositoryImpl.kt
@@ -40,8 +40,8 @@ internal class SdkInitializationRepositoryImpl(
                     .onEach { siteId ->
                         sdkInitializationLocalDataSource.setSiteId(publicKey, siteId)
                     }
-                    .catch { error ->
-                        setSiteId(publicKey, countryCode)
+                    .catch { _ ->
+                        setSiteId(publicKey, countryCode).first()
                         emitAll(sdkInitializationLocalDataSource.getSiteId(publicKey))
                     }
             )

--- a/sdk-android/src/main/java/com/mercadopago/sdk/android/data/repository/SdkInitializationRepositoryImpl.kt
+++ b/sdk-android/src/main/java/com/mercadopago/sdk/android/data/repository/SdkInitializationRepositoryImpl.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retry
 import kotlinx.coroutines.flow.timeout
@@ -25,16 +27,24 @@ internal class SdkInitializationRepositoryImpl(
 ) : SdkInitializationRepository {
 
     @OptIn(FlowPreview::class)
-    override fun fetchSiteId(publicKey: String): Flow<SiteId> {
-        return sdkInitializationRemoteDataSource.fetchSiteId(publicKey)
-            .retry(MAX_RETRY_COUNT)
-            .timeout(TIMEOUT.toDuration(DurationUnit.MILLISECONDS))
-            .onEach { siteId ->
-                sdkInitializationLocalDataSource.setSiteId(publicKey, siteId)
-            }
-            .catch { error ->
-                emitAll(sdkInitializationLocalDataSource.getSiteId(publicKey))
-            }
+    override fun fetchSiteId(publicKey: String): Flow<SiteId> = flow {
+        val cachedSiteId: SiteId = sdkInitializationLocalDataSource.getSiteId(publicKey).first()
+
+        if (cachedSiteId.siteId.isNotEmpty()) {
+            emit(cachedSiteId)
+        } else {
+            emitAll(
+                sdkInitializationRemoteDataSource.fetchSiteId(publicKey)
+                    .retry(MAX_RETRY_COUNT)
+                    .timeout(TIMEOUT.toDuration(DurationUnit.MILLISECONDS))
+                    .onEach { siteId ->
+                        sdkInitializationLocalDataSource.setSiteId(publicKey, siteId)
+                    }
+                    .catch { _ ->
+                        emitAll(sdkInitializationLocalDataSource.getSiteId(publicKey))
+                    }
+            )
+        }
     }
 
     override fun getSiteId(publicKey: String): Flow<SiteId> {

--- a/sdk-android/src/main/java/com/mercadopago/sdk/android/domain/repository/SdkInitializationRepository.kt
+++ b/sdk-android/src/main/java/com/mercadopago/sdk/android/domain/repository/SdkInitializationRepository.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 
 internal interface SdkInitializationRepository {
 
-    fun fetchSiteId(publicKey: String): Flow<SiteId>
+    fun fetchSiteId(publicKey: String, countryCode: CountryCode): Flow<SiteId>
 
     fun getSiteId(publicKey: String): Flow<SiteId>
 

--- a/sdk-android/src/main/java/com/mercadopago/sdk/android/domain/usecase/FetchSiteIdUseCase.kt
+++ b/sdk-android/src/main/java/com/mercadopago/sdk/android/domain/usecase/FetchSiteIdUseCase.kt
@@ -13,7 +13,7 @@ internal class FetchSiteIdUseCase(
 ) {
 
     operator fun invoke(publicKey: String, countryCode: CountryCode): Flow<SiteId> {
-        return sdkInitializationRepository.fetchSiteId(publicKey)
+        return sdkInitializationRepository.fetchSiteId(publicKey, countryCode)
             .map { siteId ->
                 if (siteId.siteId.isEmpty()) {
                     SiteId(UNKNOWN_SITE_ID)

--- a/sdk-android/src/main/java/com/mercadopago/sdk/android/domain/usecase/FetchSiteIdUseCase.kt
+++ b/sdk-android/src/main/java/com/mercadopago/sdk/android/domain/usecase/FetchSiteIdUseCase.kt
@@ -1,5 +1,6 @@
 package com.mercadopago.sdk.android.domain.usecase
 
+import com.mercadopago.sdk.android.domain.model.CountryCode
 import com.mercadopago.sdk.android.domain.model.SiteId
 import com.mercadopago.sdk.android.domain.repository.SdkInitializationRepository
 import kotlinx.coroutines.flow.Flow
@@ -11,7 +12,7 @@ internal class FetchSiteIdUseCase(
     private val sdkInitializationRepository: SdkInitializationRepository,
 ) {
 
-    operator fun invoke(publicKey: String): Flow<SiteId> {
+    operator fun invoke(publicKey: String, countryCode: CountryCode): Flow<SiteId> {
         return sdkInitializationRepository.fetchSiteId(publicKey)
             .map { siteId ->
                 if (siteId.siteId.isEmpty()) {

--- a/sdk-android/src/main/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDK.kt
+++ b/sdk-android/src/main/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDK.kt
@@ -11,7 +11,6 @@ import com.mercadopago.sdk.android.di.MercadoPagoSdkModulesProvider
 import com.mercadopago.sdk.android.domain.model.CountryCode
 import com.mercadopago.sdk.android.domain.usecase.FetchSiteIdUseCase
 import com.mercadopago.sdk.android.domain.usecase.GetSiteIdUseCase
-import com.mercadopago.sdk.android.domain.usecase.SetSiteIdUseCase
 import com.mercadopago.sdk.android.initializer.analytics.SdkInitializerAnalytics
 import com.mercadopago.sdk.android.initializer.coroutines.SdkCoroutineProvider
 import com.mercadopago.sdk.android.initializer.exceptions.EmptyPublicKeyException
@@ -19,7 +18,6 @@ import com.mercadopago.sdk.android.initializer.exceptions.SDKAlreadyInitializedE
 import com.mercadopago.sdk.android.initializer.exceptions.SDKNotInitializedException
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.koin.core.Koin

--- a/sdk-android/src/main/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDK.kt
+++ b/sdk-android/src/main/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDK.kt
@@ -91,8 +91,6 @@ class MercadoPagoSDK private constructor(
             SdkCoroutineProvider.provideSDKCoroutineScope().launch {
                 val fetchSiteIdUseCase = modulesProvider.koinApp.get<FetchSiteIdUseCase>()
                 val getSiteIdUseCase = modulesProvider.koinApp.get<GetSiteIdUseCase>()
-                val setSiteIdUseCase = modulesProvider.koinApp.get<SetSiteIdUseCase>()
-                setSiteIdUseCase(publicKey, countryCode).firstOrNull()
                 DeviceSDK.getInstance().execute(context)
                 MPAnalytics.initialize(
                     context = context,

--- a/sdk-android/src/main/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDK.kt
+++ b/sdk-android/src/main/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDK.kt
@@ -96,7 +96,7 @@ class MercadoPagoSDK private constructor(
                         siteId.siteId
                     },
                 )
-                fetchSiteIdUseCase(publicKey)
+                fetchSiteIdUseCase(publicKey, countryCode)
                     .catch { error ->
                         Log.d(TAG, "Error initializing SDK: ${error.message}", error)
                         MPAnalytics.getInstance().trackMetric(

--- a/sdk-android/src/test/java/com/mercadopago/sdk/android/data/repository/SdkInitializationRepositoryTest.kt
+++ b/sdk-android/src/test/java/com/mercadopago/sdk/android/data/repository/SdkInitializationRepositoryTest.kt
@@ -9,6 +9,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
+import io.mockk.verifySequence
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -25,15 +26,44 @@ internal class SdkInitializationRepositoryTest {
     )
 
     @Test
-    fun `when fetchSiteId is called with success Then emit siteId and save it`() = runTest {
+    fun `when fetchSiteId is called and cache is valid Then return cached siteId without remote call`() = runTest {
         // Given
         val publicKey = "public_key"
-        val siteId = SiteId("123")
+        val cachedSiteId = SiteId("cached_123")
+        every {
+            sdkInitializationLocalDataSource.getSiteId(publicKey)
+        } returns flowOf(cachedSiteId)
+
+        // When
+        val result = repository.fetchSiteId(publicKey)
+
+        // Then
+        result.test {
+            assertEquals(cachedSiteId, awaitItem())
+            awaitComplete()
+        }
+        verify(exactly = 1) {
+            sdkInitializationLocalDataSource.getSiteId(publicKey)
+        }
+        verify(exactly = 0) {
+            sdkInitializationRemoteDataSource.fetchSiteId(any())
+        }
+    }
+
+    @Test
+    fun `when fetchSiteId is called and cache is empty Then fetch from remote and save it`() = runTest {
+        // Given
+        val publicKey = "public_key"
+        val emptySiteId = SiteId("")
+        val remoteSiteId = SiteId("remote_123")
+        every {
+            sdkInitializationLocalDataSource.getSiteId(publicKey)
+        } returns flowOf(emptySiteId)
         every {
             sdkInitializationRemoteDataSource.fetchSiteId(publicKey)
-        } returns flowOf(siteId)
+        } returns flowOf(remoteSiteId)
         every {
-            sdkInitializationLocalDataSource.setSiteId(publicKey, siteId)
+            sdkInitializationLocalDataSource.setSiteId(publicKey, remoteSiteId)
         } returns flowOf(Unit)
 
         // When
@@ -41,39 +71,72 @@ internal class SdkInitializationRepositoryTest {
 
         // Then
         result.test {
-            assertEquals(siteId, awaitItem())
+            assertEquals(remoteSiteId, awaitItem())
             awaitComplete()
         }
-        verifyOrder {
+        verifySequence {
+            sdkInitializationLocalDataSource.getSiteId(publicKey)
             sdkInitializationRemoteDataSource.fetchSiteId(publicKey)
-            sdkInitializationLocalDataSource.setSiteId(publicKey, siteId)
+            sdkInitializationLocalDataSource.setSiteId(publicKey, remoteSiteId)
         }
     }
 
     @Test
-    fun `when fetchSiteId is called with error Then emit saved siteId`() = runTest {
+    fun `when fetchSiteId is called with empty cache and remote error Then return cached empty siteId`() = runTest {
         // Given
-        val exception = Exception()
         val publicKey = "public_key"
-        val siteId = SiteId("123")
+        val emptySiteId = SiteId("")
+        val exception = Exception("Network error")
+        every {
+            sdkInitializationLocalDataSource.getSiteId(publicKey)
+        } returns flowOf(emptySiteId)
         every {
             sdkInitializationRemoteDataSource.fetchSiteId(publicKey)
         } returns flow { throw exception }
-        every {
-            sdkInitializationLocalDataSource.getSiteId(publicKey)
-        } returns flowOf(siteId)
 
         // When
         val result = repository.fetchSiteId(publicKey)
 
         // Then
         result.test {
-            assertEquals(siteId, awaitItem())
+            assertEquals(emptySiteId, awaitItem())
             awaitComplete()
         }
-        verifyOrder {
+        verifySequence {
+            sdkInitializationLocalDataSource.getSiteId(publicKey)
             sdkInitializationRemoteDataSource.fetchSiteId(publicKey)
             sdkInitializationLocalDataSource.getSiteId(publicKey)
+        }
+    }
+
+    @Test
+    fun `when fetchSiteId is called and cache has null or empty siteId Then fetch from remote`() = runTest {
+        // Given
+        val publicKey = "public_key"
+        val nullSiteId = SiteId("")
+        val remoteSiteId = SiteId("remote_456")
+        every {
+            sdkInitializationLocalDataSource.getSiteId(publicKey)
+        } returns flowOf(nullSiteId)
+        every {
+            sdkInitializationRemoteDataSource.fetchSiteId(publicKey)
+        } returns flowOf(remoteSiteId)
+        every {
+            sdkInitializationLocalDataSource.setSiteId(publicKey, remoteSiteId)
+        } returns flowOf(Unit)
+
+        // When
+        val result = repository.fetchSiteId(publicKey)
+
+        // Then
+        result.test {
+            assertEquals(remoteSiteId, awaitItem())
+            awaitComplete()
+        }
+        verify(exactly = 1) {
+            sdkInitializationLocalDataSource.getSiteId(publicKey)
+            sdkInitializationRemoteDataSource.fetchSiteId(publicKey)
+            sdkInitializationLocalDataSource.setSiteId(publicKey, remoteSiteId)
         }
     }
 

--- a/sdk-android/src/test/java/com/mercadopago/sdk/android/data/repository/SdkInitializationRepositoryTest.kt
+++ b/sdk-android/src/test/java/com/mercadopago/sdk/android/data/repository/SdkInitializationRepositoryTest.kt
@@ -28,13 +28,14 @@ internal class SdkInitializationRepositoryTest {
     fun `when fetchSiteId is called and cache is valid Then return cached siteId without remote call`() = runTest {
         // Given
         val publicKey = "public_key"
+        val countryCode = CountryCode.ARG
         val cachedSiteId = SiteId("cached_123")
         every {
             sdkInitializationLocalDataSource.getSiteId(publicKey)
         } returns flowOf(cachedSiteId)
 
         // When
-        val result = repository.fetchSiteId(publicKey)
+        val result = repository.fetchSiteId(publicKey, countryCode)
 
         // Then
         result.test {
@@ -53,6 +54,7 @@ internal class SdkInitializationRepositoryTest {
     fun `when fetchSiteId is called and cache is empty Then fetch from remote and save it`() = runTest {
         // Given
         val publicKey = "public_key"
+        val countryCode = CountryCode.ARG
         val emptySiteId = SiteId("")
         val remoteSiteId = SiteId("remote_123")
         every {
@@ -66,7 +68,7 @@ internal class SdkInitializationRepositoryTest {
         } returns flowOf(Unit)
 
         // When
-        val result = repository.fetchSiteId(publicKey)
+        val result = repository.fetchSiteId(publicKey, countryCode)
 
         // Then
         result.test {
@@ -81,29 +83,35 @@ internal class SdkInitializationRepositoryTest {
     }
 
     @Test
-    fun `when fetchSiteId is called with empty cache and remote error Then return cached empty siteId`() = runTest {
+    fun `when fetchSiteId is called with empty cache and remote error Then save countryCode and return it`() = runTest {
         // Given
         val publicKey = "public_key"
+        val countryCode = CountryCode.ARG
         val emptySiteId = SiteId("")
+        val savedSiteId = SiteId("MLA") // siteId baseado no countryCode ARG
         val exception = Exception("Network error")
         every {
             sdkInitializationLocalDataSource.getSiteId(publicKey)
-        } returns flowOf(emptySiteId)
+        } returns flowOf(emptySiteId) andThen flowOf(savedSiteId)
         every {
             sdkInitializationRemoteDataSource.fetchSiteId(publicKey)
         } returns flow { throw exception }
+        every {
+            sdkInitializationLocalDataSource.setSiteId(publicKey, savedSiteId)
+        } returns flowOf(Unit)
 
         // When
-        val result = repository.fetchSiteId(publicKey)
+        val result = repository.fetchSiteId(publicKey, countryCode)
 
         // Then
         result.test {
-            assertEquals(emptySiteId, awaitItem())
+            assertEquals(savedSiteId, awaitItem())
             awaitComplete()
         }
         verifySequence {
             sdkInitializationLocalDataSource.getSiteId(publicKey)
             sdkInitializationRemoteDataSource.fetchSiteId(publicKey)
+            sdkInitializationLocalDataSource.setSiteId(publicKey, savedSiteId)
             sdkInitializationLocalDataSource.getSiteId(publicKey)
         }
     }
@@ -112,6 +120,7 @@ internal class SdkInitializationRepositoryTest {
     fun `when fetchSiteId is called and cache has null or empty siteId Then fetch from remote`() = runTest {
         // Given
         val publicKey = "public_key"
+        val countryCode = CountryCode.BRA
         val nullSiteId = SiteId("")
         val remoteSiteId = SiteId("remote_456")
         every {
@@ -125,7 +134,7 @@ internal class SdkInitializationRepositoryTest {
         } returns flowOf(Unit)
 
         // When
-        val result = repository.fetchSiteId(publicKey)
+        val result = repository.fetchSiteId(publicKey, countryCode)
 
         // Then
         result.test {

--- a/sdk-android/src/test/java/com/mercadopago/sdk/android/data/repository/SdkInitializationRepositoryTest.kt
+++ b/sdk-android/src/test/java/com/mercadopago/sdk/android/data/repository/SdkInitializationRepositoryTest.kt
@@ -8,7 +8,6 @@ import com.mercadopago.sdk.android.domain.model.SiteId
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import io.mockk.verifyOrder
 import io.mockk.verifySequence
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf

--- a/sdk-android/src/test/java/com/mercadopago/sdk/android/domain/usecase/FetchSiteIdUseCaseTest.kt
+++ b/sdk-android/src/test/java/com/mercadopago/sdk/android/domain/usecase/FetchSiteIdUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.mercadopago.sdk.android.domain.usecase
 
 import app.cash.turbine.test
+import com.mercadopago.sdk.android.domain.model.CountryCode
 import com.mercadopago.sdk.android.domain.model.SiteId
 import com.mercadopago.sdk.android.domain.repository.SdkInitializationRepository
 import io.mockk.every
@@ -21,10 +22,11 @@ internal class FetchSiteIdUseCaseTest {
         // Given
         val siteId = SiteId("123")
         val publicKey = "public_key"
-        every { sdkInitializationRepository.fetchSiteId(publicKey) } returns flowOf(siteId)
+        val countryCode = CountryCode.ARG
+        every { sdkInitializationRepository.fetchSiteId(publicKey, countryCode) } returns flowOf(siteId)
 
         // When
-        val result = useCase(publicKey)
+        val result = useCase(publicKey, countryCode)
 
         // Then
         result.test {
@@ -38,12 +40,13 @@ internal class FetchSiteIdUseCaseTest {
         // Given
         val exception = Exception()
         val publicKey = "public_key"
+        val countryCode = CountryCode.BRA
         every {
-            sdkInitializationRepository.fetchSiteId(publicKey)
+            sdkInitializationRepository.fetchSiteId(publicKey, countryCode)
         } returns flow { throw exception }
 
         // When
-        val result = useCase(publicKey)
+        val result = useCase(publicKey, countryCode)
 
         // Then
         result.test {

--- a/sdk-android/src/test/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDKTest.kt
+++ b/sdk-android/src/test/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDKTest.kt
@@ -10,7 +10,6 @@ import com.mercadopago.sdk.android.domain.model.CountryCode
 import com.mercadopago.sdk.android.domain.model.SiteId
 import com.mercadopago.sdk.android.domain.usecase.FetchSiteIdUseCase
 import com.mercadopago.sdk.android.domain.usecase.GetSiteIdUseCase
-import com.mercadopago.sdk.android.domain.usecase.SetSiteIdUseCase
 import com.mercadopago.sdk.android.initializer.analytics.SdkInitializerAnalytics
 import com.mercadopago.sdk.android.initializer.coroutines.SdkCoroutineProvider
 import com.mercadopago.sdk.android.initializer.exceptions.EmptyPublicKeyException
@@ -41,7 +40,6 @@ internal class MercadoPagoSDKTest {
     private val koin = mockk<Koin>(relaxed = true)
     private val fetchSiteIdUseCase = mockk<FetchSiteIdUseCase>(relaxed = true)
     private val getSiteIdUseCase = mockk<GetSiteIdUseCase>(relaxed = true)
-    private val setSiteIdUseCase = mockk<SetSiteIdUseCase>(relaxed = true)
     private val mpAnalytics = mockk<MPAnalytics>(relaxed = true)
     private val deviceSDK = mockk<DeviceSDK>(relaxed = true)
 
@@ -73,9 +71,6 @@ internal class MercadoPagoSDKTest {
         every {
             koin.get<GetSiteIdUseCase>()
         } returns getSiteIdUseCase
-        every {
-            koin.get<SetSiteIdUseCase>()
-        } returns setSiteIdUseCase
         every {
             MPAnalytics.getInstance()
         } returns mpAnalytics
@@ -113,7 +108,6 @@ internal class MercadoPagoSDKTest {
         // Then
         assertNotNull(MercadoPagoSDK.getInstance())
         verifyOrder {
-            setSiteIdUseCase(publicKey, countryCode)
             fetchSiteIdUseCase(publicKey)
             mpAnalytics.trackMetric(sdkInitializerEvent)
         }
@@ -146,7 +140,6 @@ internal class MercadoPagoSDKTest {
         // Then
         assertNotNull(MercadoPagoSDK.getInstance())
         verifyOrder {
-            setSiteIdUseCase(publicKey, countryCode)
             fetchSiteIdUseCase(publicKey)
             Log.d(any(), any(), exception)
             mpAnalytics.trackMetric(any())
@@ -188,7 +181,6 @@ internal class MercadoPagoSDKTest {
             awaitError() is SDKAlreadyInitializedException
         }
         verifyOrder {
-            setSiteIdUseCase(publicKey, countryCode)
             fetchSiteIdUseCase(publicKey)
             mpAnalytics.trackMetric(sdkInitializerEvent)
         }

--- a/sdk-android/src/test/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDKTest.kt
+++ b/sdk-android/src/test/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDKTest.kt
@@ -91,7 +91,7 @@ internal class MercadoPagoSDKTest {
         val countryCode = CountryCode.ARG
         val siteId = SiteId("MLA")
         every {
-            fetchSiteIdUseCase(publicKey)
+            fetchSiteIdUseCase(publicKey, countryCode)
         } returns flowOf(siteId)
         val sdkInitializerEvent = SdkInitializerAnalytics.buildSdkInitializerEvent(context, publicKey)
         every {
@@ -108,7 +108,7 @@ internal class MercadoPagoSDKTest {
         // Then
         assertNotNull(MercadoPagoSDK.getInstance())
         verifyOrder {
-            fetchSiteIdUseCase(publicKey)
+            fetchSiteIdUseCase(publicKey, countryCode)
             mpAnalytics.trackMetric(sdkInitializerEvent)
         }
     }
@@ -120,7 +120,7 @@ internal class MercadoPagoSDKTest {
         val countryCode = CountryCode.ARG
         val exception = Exception()
         every {
-            fetchSiteIdUseCase(publicKey)
+            fetchSiteIdUseCase(publicKey, countryCode)
         } returns flow { throw exception }
         val sdkInitializerEvent = SdkInitializerAnalytics.buildSdkInitializerEvent(
             context = context,
@@ -140,7 +140,7 @@ internal class MercadoPagoSDKTest {
         // Then
         assertNotNull(MercadoPagoSDK.getInstance())
         verifyOrder {
-            fetchSiteIdUseCase(publicKey)
+            fetchSiteIdUseCase(publicKey, countryCode)
             Log.d(any(), any(), exception)
             mpAnalytics.trackMetric(any())
         }
@@ -153,7 +153,7 @@ internal class MercadoPagoSDKTest {
         val countryCode = CountryCode.ARG
         val siteId = SiteId("MLA")
         every {
-            fetchSiteIdUseCase(publicKey)
+            fetchSiteIdUseCase(publicKey, countryCode)
         } returns flowOf(siteId)
         val sdkInitializerEvent = SdkInitializerAnalytics.buildSdkInitializerEvent(context, publicKey)
         every {
@@ -181,7 +181,7 @@ internal class MercadoPagoSDKTest {
             awaitError() is SDKAlreadyInitializedException
         }
         verifyOrder {
-            fetchSiteIdUseCase(publicKey)
+            fetchSiteIdUseCase(publicKey, countryCode)
             mpAnalytics.trackMetric(sdkInitializerEvent)
         }
     }


### PR DESCRIPTION
# Pull Request
Changed site id fetch to call cache first
## Ticket or Issue link
<!--Provide link for your issue or ticket that describes this pull request-->

## Description
Changed repository implementation to verify the cache first then if not exists call a fetch
```
 override fun fetchSiteId(publicKey: String): Flow<SiteId> = flow {
        val cachedSiteId: SiteId = sdkInitializationLocalDataSource.getSiteId(publicKey).first()

        if (cachedSiteId.siteId.isNotEmpty()) {
            emit(cachedSiteId)
        } else {
            emitAll(
                sdkInitializationRemoteDataSource.fetchSiteId(publicKey)
                    .retry(MAX_RETRY_COUNT)
                    .timeout(TIMEOUT.toDuration(DurationUnit.MILLISECONDS))
                    .onEach { siteId ->
                        sdkInitializationLocalDataSource.setSiteId(publicKey, siteId)
                    }
                    .catch { _ ->
                        emitAll(sdkInitializationLocalDataSource.getSiteId(publicKey))
                    }
            )
        }
    }
```

## Checklist
- [ ] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [ ] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<!---
Provide videos or screenshots. You can change their size in the src
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>
-->
