### PR TITLE
[3566](Feature): Component Header

### DIFF
--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/cardpayment/CardPaymentScreenContent.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/cardpayment/CardPaymentScreenContent.kt
@@ -123,136 +123,136 @@ internal fun CardPaymentScreenContent(
                 onBackClick = onBackClick,
                 headerType = MPHeaderType.ScrollOff,
             ) {
-            var containerBounds by remember { mutableStateOf(Rect.Zero) }
-            var securityCodeBounds by remember { mutableStateOf(Rect.Zero) }
-            val density = LocalDensity.current
-            val popoverHeightPx = with(density) { 80.dp.toPx() }
-            Box(
-                modifier = Modifier
-                    .onGloballyPositioned { containerBounds = it.boundsInRoot() },
-            ) {
-                Column(
+                var containerBounds by remember { mutableStateOf(Rect.Zero) }
+                var securityCodeBounds by remember { mutableStateOf(Rect.Zero) }
+                val density = LocalDensity.current
+                val popoverHeightPx = with(density) { 80.dp.toPx() }
+                Box(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
+                        .onGloballyPositioned { containerBounds = it.boundsInRoot() },
                 ) {
-                    Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                    MPCardNumberTextField(
-                        modifier = Modifier.fillMaxWidth(),
-                        state = cardNumberPCIState,
-                        isFocused = viewState.cardNumberState.isFocused,
-                        showPlaceHolder = viewState.cardNumberState.showPlaceHolder,
-                        error = viewState.cardNumberState.error,
-                        enabled = viewState.cardNumberState.enabled,
-                        label = viewState.cardNumberState.label,
-                        helper = viewState.cardNumberState.helper,
-                        placeHolder = viewState.cardNumberState.placeHolder,
-                        onEvent = onCardNumberEvent,
-                    )
-
-                    if (viewState.cardHolderState.show) {
-                        Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                        MPSimpleTextField(
-                            modifier = Modifier.fillMaxWidth(),
-                            state = cardHolderPCIState,
-                            isFocused = viewState.cardHolderState.isFocused,
-                            showPlaceHolder = viewState.cardHolderState.showPlaceHolder,
-                            error = viewState.cardHolderState.error,
-                            enabled = viewState.cardHolderState.enabled,
-                            label = viewState.cardHolderState.label,
-                            helper = viewState.cardHolderState.helper,
-                            placeHolder = viewState.cardHolderState.placeHolder,
-                            onEvent = onCardHolderEvent,
-                        )
-                    }
-
-                    Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                    MPExpirationDateTextField(
-                        state = expirationDatePCIState,
-                        isFocused = viewState.expirationDateState.isFocused,
-                        showPlaceHolder = viewState.expirationDateState.showPlaceHolder,
-                        error = viewState.expirationDateState.error,
-                        enabled = viewState.expirationDateState.enabled,
-                        label = viewState.expirationDateState.label,
-                        helper = viewState.expirationDateState.helper,
-                        placeHolder = viewState.expirationDateState.placeHolder,
-                        onEvent = onExpirationDateEvent,
-                    )
-
-                    Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                    Box(
-                        modifier = Modifier.onGloballyPositioned {
-                            securityCodeBounds = it.boundsInRoot()
-                        },
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
                     ) {
-                        MPSecurityCodeTextField(
-                            state = securityCodePCIState,
-                            securityCodeSize = viewState.secureCodeState.secureCodeLength,
-                            isFocused = viewState.secureCodeState.isFocused,
-                            showPlaceHolder = viewState.secureCodeState.showPlaceHolder,
-                            error = viewState.secureCodeState.error,
-                            enabled = viewState.secureCodeState.enabled,
-                            label = viewState.secureCodeState.label,
-                            helper = viewState.secureCodeState.helper,
-                            placeHolder = viewState.secureCodeState.placeHolder,
-                            onClickTooltip = onTooltipClick,
-                            onEvent = onSecurityCodeEvent,
-                        )
-                    }
-
-                    if (viewState.identificationTypeState.show) {
                         Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                        viewState.identificationTypeState.identificationTypes?.let { types ->
-                            MPIdentificationTextField(
+                        MPCardNumberTextField(
+                            modifier = Modifier.fillMaxWidth(),
+                            state = cardNumberPCIState,
+                            isFocused = viewState.cardNumberState.isFocused,
+                            showPlaceHolder = viewState.cardNumberState.showPlaceHolder,
+                            error = viewState.cardNumberState.error,
+                            enabled = viewState.cardNumberState.enabled,
+                            label = viewState.cardNumberState.label,
+                            helper = viewState.cardNumberState.helper,
+                            placeHolder = viewState.cardNumberState.placeHolder,
+                            onEvent = onCardNumberEvent,
+                        )
+
+                        if (viewState.cardHolderState.show) {
+                            Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
+                            MPSimpleTextField(
                                 modifier = Modifier.fillMaxWidth(),
-                                state = identificationPCIState,
-                                identificationTypes = types,
-                                selectedIdentificationType = viewState.identificationTypeState.selected,
-                                isFocused = viewState.identificationTypeState.isFocused,
-                                showPlaceHolder = viewState.identificationTypeState.showPlaceHolder,
-                                error = viewState.identificationTypeState.error,
-                                enabled = viewState.identificationTypeState.enabled,
-                                label = viewState.identificationTypeState.label,
-                                helper = viewState.identificationTypeState.helper,
-                                placeHolder = viewState.identificationTypeState.placeHolder,
-                                onEvent = onIdentificationEvent,
+                                state = cardHolderPCIState,
+                                isFocused = viewState.cardHolderState.isFocused,
+                                showPlaceHolder = viewState.cardHolderState.showPlaceHolder,
+                                error = viewState.cardHolderState.error,
+                                enabled = viewState.cardHolderState.enabled,
+                                label = viewState.cardHolderState.label,
+                                helper = viewState.cardHolderState.helper,
+                                placeHolder = viewState.cardHolderState.placeHolder,
+                                onEvent = onCardHolderEvent,
+                            )
+                        }
+
+                        Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
+                        MPExpirationDateTextField(
+                            state = expirationDatePCIState,
+                            isFocused = viewState.expirationDateState.isFocused,
+                            showPlaceHolder = viewState.expirationDateState.showPlaceHolder,
+                            error = viewState.expirationDateState.error,
+                            enabled = viewState.expirationDateState.enabled,
+                            label = viewState.expirationDateState.label,
+                            helper = viewState.expirationDateState.helper,
+                            placeHolder = viewState.expirationDateState.placeHolder,
+                            onEvent = onExpirationDateEvent,
+                        )
+
+                        Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
+                        Box(
+                            modifier = Modifier.onGloballyPositioned {
+                                securityCodeBounds = it.boundsInRoot()
+                            },
+                        ) {
+                            MPSecurityCodeTextField(
+                                state = securityCodePCIState,
+                                securityCodeSize = viewState.secureCodeState.secureCodeLength,
+                                isFocused = viewState.secureCodeState.isFocused,
+                                showPlaceHolder = viewState.secureCodeState.showPlaceHolder,
+                                error = viewState.secureCodeState.error,
+                                enabled = viewState.secureCodeState.enabled,
+                                label = viewState.secureCodeState.label,
+                                helper = viewState.secureCodeState.helper,
+                                placeHolder = viewState.secureCodeState.placeHolder,
+                                onClickTooltip = onTooltipClick,
+                                onEvent = onSecurityCodeEvent,
+                            )
+                        }
+
+                        if (viewState.identificationTypeState.show) {
+                            Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
+                            viewState.identificationTypeState.identificationTypes?.let { types ->
+                                MPIdentificationTextField(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    state = identificationPCIState,
+                                    identificationTypes = types,
+                                    selectedIdentificationType = viewState.identificationTypeState.selected,
+                                    isFocused = viewState.identificationTypeState.isFocused,
+                                    showPlaceHolder = viewState.identificationTypeState.showPlaceHolder,
+                                    error = viewState.identificationTypeState.error,
+                                    enabled = viewState.identificationTypeState.enabled,
+                                    label = viewState.identificationTypeState.label,
+                                    helper = viewState.identificationTypeState.helper,
+                                    placeHolder = viewState.identificationTypeState.placeHolder,
+                                    onEvent = onIdentificationEvent,
+                                )
+                            }
+                        }
+                    }
+                    if (viewState.showTooltip && securityCodeBounds != Rect.Zero && containerBounds != Rect.Zero) {
+                        val relativeSecurityCodeTop = securityCodeBounds.top - containerBounds.top
+                        val popoverY = (relativeSecurityCodeTop - popoverHeightPx).roundToInt()
+                            .coerceAtLeast(0)
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.TopCenter)
+                                .offset { IntOffset(0, popoverY) },
+                        ) {
+                            MPPopover(
+                                description = "É um número de ${viewState.secureCodeState.secureCodeLength} dígitos. " +
+                                    "Está atrás do cartão ou no app do seu banco.",
+                                onDismiss = onTooltipClick,
                             )
                         }
                     }
-                }
-                if (viewState.showTooltip && securityCodeBounds != Rect.Zero && containerBounds != Rect.Zero) {
-                    val relativeSecurityCodeTop = securityCodeBounds.top - containerBounds.top
-                    val popoverY = (relativeSecurityCodeTop - popoverHeightPx).roundToInt()
-                        .coerceAtLeast(0)
-                    Box(
-                        modifier = Modifier
-                            .align(Alignment.TopCenter)
-                            .offset { IntOffset(0, popoverY) },
-                    ) {
-                        MPPopover(
-                            description = "É um número de ${viewState.secureCodeState.secureCodeLength} dígitos. " +
-                                "Está atrás do cartão ou no app do seu banco.",
-                            onDismiss = onTooltipClick,
-                        )
-                    }
-                }
 
-                if (viewState.showMessage) {
-                    Column(
-                        modifier = Modifier
-                            .align(Alignment.BottomCenter)
-                            .padding(10.dp),
-                    ) {
-                        MPMessage(
-                            text = viewState.messageError.description,
-                            type = MPMessageType.Negative,
+                    if (viewState.showMessage) {
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .padding(10.dp),
                         ) {
-                            onMessageClick()
+                            MPMessage(
+                                text = viewState.messageError.description,
+                                type = MPMessageType.Negative,
+                            ) {
+                                onMessageClick()
+                            }
                         }
                     }
                 }
             }
-        }
         }
         MPFixedFooter(
             title = viewState.fixedFooterState.title,

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/cardpayment/CardPaymentScreenContent.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/cardpayment/CardPaymentScreenContent.kt
@@ -111,12 +111,18 @@ internal fun CardPaymentScreenContent(
     onTooltipClick: () -> Unit = {},
     onMessageClick: () -> Unit = {},
 ) {
-    Column {
-        MPHeader(
-            title = "Preencha os dados do\ncartão",
-            onBackClick = onBackClick,
-            headerType = MPHeaderType.ScrollOff,
+    Column(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
         ) {
+            MPHeader(
+                modifier = Modifier.fillMaxSize(),
+                title = "Preencha os dados do\ncartão",
+                onBackClick = onBackClick,
+                headerType = MPHeaderType.ScrollOff,
+            ) {
             var containerBounds by remember { mutableStateOf(Rect.Zero) }
             var securityCodeBounds by remember { mutableStateOf(Rect.Zero) }
             val density = LocalDensity.current
@@ -246,6 +252,7 @@ internal fun CardPaymentScreenContent(
                     }
                 }
             }
+        }
         }
         MPFixedFooter(
             title = viewState.fixedFooterState.title,

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/cardpayment/CardPaymentScreenContent.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/cardpayment/CardPaymentScreenContent.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -38,6 +36,7 @@ import com.mercadopago.sdk.android.components.MPAmountData
 import com.mercadopago.sdk.android.components.MPFixedFooter
 import com.mercadopago.sdk.android.components.MPFixedFooterButtonData
 import com.mercadopago.sdk.android.components.MPHeader
+import com.mercadopago.sdk.android.components.MPHeaderType
 import com.mercadopago.sdk.android.components.MPMessage
 import com.mercadopago.sdk.android.components.MPMessageType
 import com.mercadopago.sdk.android.components.MPPopover
@@ -112,159 +111,156 @@ internal fun CardPaymentScreenContent(
     onTooltipClick: () -> Unit = {},
     onMessageClick: () -> Unit = {},
 ) {
-    MPHeader(
-        title = "Preencha os dados do\ncartão",
-        onBackClick = onBackClick,
-    ) {
-        var containerBounds by remember { mutableStateOf(Rect.Zero) }
-        var securityCodeBounds by remember { mutableStateOf(Rect.Zero) }
-        val density = LocalDensity.current
-        val popoverHeightPx = with(density) { 80.dp.toPx() }
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .onGloballyPositioned { containerBounds = it.boundsInRoot() },
+    Column {
+        MPHeader(
+            title = "Preencha os dados do\ncartão",
+            onBackClick = onBackClick,
+            headerType = MPHeaderType.ScrollOff,
         ) {
-            Column(
+            var containerBounds by remember { mutableStateOf(Rect.Zero) }
+            var securityCodeBounds by remember { mutableStateOf(Rect.Zero) }
+            val density = LocalDensity.current
+            val popoverHeightPx = with(density) { 80.dp.toPx() }
+            Box(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 120.dp)
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 16.dp),
+                    .onGloballyPositioned { containerBounds = it.boundsInRoot() },
             ) {
-                Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                MPCardNumberTextField(
-                    modifier = Modifier.fillMaxWidth(),
-                    state = cardNumberPCIState,
-                    isFocused = viewState.cardNumberState.isFocused,
-                    showPlaceHolder = viewState.cardNumberState.showPlaceHolder,
-                    error = viewState.cardNumberState.error,
-                    enabled = viewState.cardNumberState.enabled,
-                    label = viewState.cardNumberState.label,
-                    helper = viewState.cardNumberState.helper,
-                    placeHolder = viewState.cardNumberState.placeHolder,
-                    onEvent = onCardNumberEvent,
-                )
-
-                if (viewState.cardHolderState.show) {
-                    Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                    MPSimpleTextField(
-                        modifier = Modifier.fillMaxWidth(),
-                        state = cardHolderPCIState,
-                        isFocused = viewState.cardHolderState.isFocused,
-                        showPlaceHolder = viewState.cardHolderState.showPlaceHolder,
-                        error = viewState.cardHolderState.error,
-                        enabled = viewState.cardHolderState.enabled,
-                        label = viewState.cardHolderState.label,
-                        helper = viewState.cardHolderState.helper,
-                        placeHolder = viewState.cardHolderState.placeHolder,
-                        onEvent = onCardHolderEvent,
-                    )
-                }
-
-                Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                MPExpirationDateTextField(
-                    state = expirationDatePCIState,
-                    isFocused = viewState.expirationDateState.isFocused,
-                    showPlaceHolder = viewState.expirationDateState.showPlaceHolder,
-                    error = viewState.expirationDateState.error,
-                    enabled = viewState.expirationDateState.enabled,
-                    label = viewState.expirationDateState.label,
-                    helper = viewState.expirationDateState.helper,
-                    placeHolder = viewState.expirationDateState.placeHolder,
-                    onEvent = onExpirationDateEvent,
-                )
-
-                Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                Box(
-                    modifier = Modifier.onGloballyPositioned {
-                        securityCodeBounds = it.boundsInRoot()
-                    },
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
                 ) {
-                    MPSecurityCodeTextField(
-                        state = securityCodePCIState,
-                        securityCodeSize = viewState.secureCodeState.secureCodeLength,
-                        isFocused = viewState.secureCodeState.isFocused,
-                        showPlaceHolder = viewState.secureCodeState.showPlaceHolder,
-                        error = viewState.secureCodeState.error,
-                        enabled = viewState.secureCodeState.enabled,
-                        label = viewState.secureCodeState.label,
-                        helper = viewState.secureCodeState.helper,
-                        placeHolder = viewState.secureCodeState.placeHolder,
-                        onClickTooltip = onTooltipClick,
-                        onEvent = onSecurityCodeEvent,
-                    )
-                }
-
-                if (viewState.identificationTypeState.show) {
                     Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                    viewState.identificationTypeState.identificationTypes?.let { types ->
-                        MPIdentificationTextField(
+                    MPCardNumberTextField(
+                        modifier = Modifier.fillMaxWidth(),
+                        state = cardNumberPCIState,
+                        isFocused = viewState.cardNumberState.isFocused,
+                        showPlaceHolder = viewState.cardNumberState.showPlaceHolder,
+                        error = viewState.cardNumberState.error,
+                        enabled = viewState.cardNumberState.enabled,
+                        label = viewState.cardNumberState.label,
+                        helper = viewState.cardNumberState.helper,
+                        placeHolder = viewState.cardNumberState.placeHolder,
+                        onEvent = onCardNumberEvent,
+                    )
+
+                    if (viewState.cardHolderState.show) {
+                        Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
+                        MPSimpleTextField(
                             modifier = Modifier.fillMaxWidth(),
-                            state = identificationPCIState,
-                            identificationTypes = types,
-                            selectedIdentificationType = viewState.identificationTypeState.selected,
-                            isFocused = viewState.identificationTypeState.isFocused,
-                            showPlaceHolder = viewState.identificationTypeState.showPlaceHolder,
-                            error = viewState.identificationTypeState.error,
-                            enabled = viewState.identificationTypeState.enabled,
-                            label = viewState.identificationTypeState.label,
-                            helper = viewState.identificationTypeState.helper,
-                            placeHolder = viewState.identificationTypeState.placeHolder,
-                            onEvent = onIdentificationEvent,
+                            state = cardHolderPCIState,
+                            isFocused = viewState.cardHolderState.isFocused,
+                            showPlaceHolder = viewState.cardHolderState.showPlaceHolder,
+                            error = viewState.cardHolderState.error,
+                            enabled = viewState.cardHolderState.enabled,
+                            label = viewState.cardHolderState.label,
+                            helper = viewState.cardHolderState.helper,
+                            placeHolder = viewState.cardHolderState.placeHolder,
+                            onEvent = onCardHolderEvent,
+                        )
+                    }
+
+                    Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
+                    MPExpirationDateTextField(
+                        state = expirationDatePCIState,
+                        isFocused = viewState.expirationDateState.isFocused,
+                        showPlaceHolder = viewState.expirationDateState.showPlaceHolder,
+                        error = viewState.expirationDateState.error,
+                        enabled = viewState.expirationDateState.enabled,
+                        label = viewState.expirationDateState.label,
+                        helper = viewState.expirationDateState.helper,
+                        placeHolder = viewState.expirationDateState.placeHolder,
+                        onEvent = onExpirationDateEvent,
+                    )
+
+                    Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
+                    Box(
+                        modifier = Modifier.onGloballyPositioned {
+                            securityCodeBounds = it.boundsInRoot()
+                        },
+                    ) {
+                        MPSecurityCodeTextField(
+                            state = securityCodePCIState,
+                            securityCodeSize = viewState.secureCodeState.secureCodeLength,
+                            isFocused = viewState.secureCodeState.isFocused,
+                            showPlaceHolder = viewState.secureCodeState.showPlaceHolder,
+                            error = viewState.secureCodeState.error,
+                            enabled = viewState.secureCodeState.enabled,
+                            label = viewState.secureCodeState.label,
+                            helper = viewState.secureCodeState.helper,
+                            placeHolder = viewState.secureCodeState.placeHolder,
+                            onClickTooltip = onTooltipClick,
+                            onEvent = onSecurityCodeEvent,
+                        )
+                    }
+
+                    if (viewState.identificationTypeState.show) {
+                        Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
+                        viewState.identificationTypeState.identificationTypes?.let { types ->
+                            MPIdentificationTextField(
+                                modifier = Modifier.fillMaxWidth(),
+                                state = identificationPCIState,
+                                identificationTypes = types,
+                                selectedIdentificationType = viewState.identificationTypeState.selected,
+                                isFocused = viewState.identificationTypeState.isFocused,
+                                showPlaceHolder = viewState.identificationTypeState.showPlaceHolder,
+                                error = viewState.identificationTypeState.error,
+                                enabled = viewState.identificationTypeState.enabled,
+                                label = viewState.identificationTypeState.label,
+                                helper = viewState.identificationTypeState.helper,
+                                placeHolder = viewState.identificationTypeState.placeHolder,
+                                onEvent = onIdentificationEvent,
+                            )
+                        }
+                    }
+                }
+                if (viewState.showTooltip && securityCodeBounds != Rect.Zero && containerBounds != Rect.Zero) {
+                    val relativeSecurityCodeTop = securityCodeBounds.top - containerBounds.top
+                    val popoverY = (relativeSecurityCodeTop - popoverHeightPx).roundToInt()
+                        .coerceAtLeast(0)
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .offset { IntOffset(0, popoverY) },
+                    ) {
+                        MPPopover(
+                            description = "É um número de ${viewState.secureCodeState.secureCodeLength} dígitos. " +
+                                "Está atrás do cartão ou no app do seu banco.",
+                            onDismiss = onTooltipClick,
                         )
                     }
                 }
-            }
-            if (viewState.showTooltip && securityCodeBounds != Rect.Zero && containerBounds != Rect.Zero) {
-                val relativeSecurityCodeTop = securityCodeBounds.top - containerBounds.top
-                val popoverY = (relativeSecurityCodeTop - popoverHeightPx).roundToInt()
-                    .coerceAtLeast(0)
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.TopCenter)
-                        .offset { IntOffset(0, popoverY) },
-                ) {
-                    MPPopover(
-                        description = "É um número de ${viewState.secureCodeState.secureCodeLength} dígitos. " +
-                            "Está atrás do cartão ou no app do seu banco.",
-                        onDismiss = onTooltipClick,
-                    )
-                }
-            }
 
-            if (viewState.showMessage) {
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(10.dp),
-                ) {
-                    MPMessage(
-                        text = viewState.messageError.description,
-                        type = MPMessageType.Negative,
+                if (viewState.showMessage) {
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(10.dp),
                     ) {
-                        onMessageClick()
+                        MPMessage(
+                            text = viewState.messageError.description,
+                            type = MPMessageType.Negative,
+                        ) {
+                            onMessageClick()
+                        }
                     }
-                    Spacer(Modifier.size(140.dp))
                 }
             }
-
-            MPFixedFooter(
-                title = viewState.fixedFooterState.title,
-                amount = MPAmountData(
-                    currencySymbol = viewState.fixedFooterState.currencySymbol,
-                    integerPart = viewState.fixedFooterState.amountIntegerPart,
-                    decimalPart = viewState.fixedFooterState.amountDecimalPart,
-                ),
-                subtitle = viewState.fixedFooterState.subtitle,
-                buttonData = MPFixedFooterButtonData(
-                    text = viewState.fixedFooterState.buttonText,
-                    enabled = viewState.fixedFooterState.buttonEnabled,
-                    onClick = onFooterButtonClick,
-                ),
-                modifier = Modifier.align(Alignment.BottomCenter),
-            )
         }
+        MPFixedFooter(
+            title = viewState.fixedFooterState.title,
+            amount = MPAmountData(
+                currencySymbol = viewState.fixedFooterState.currencySymbol,
+                integerPart = viewState.fixedFooterState.amountIntegerPart,
+                decimalPart = viewState.fixedFooterState.amountDecimalPart,
+            ),
+            subtitle = viewState.fixedFooterState.subtitle,
+            buttonData = MPFixedFooterButtonData(
+                text = viewState.fixedFooterState.buttonText,
+                enabled = viewState.fixedFooterState.buttonEnabled,
+                onClick = onFooterButtonClick,
+            ),
+        )
     }
 }
 

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/cardpayment/CardPaymentScreenContent.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/cardpayment/CardPaymentScreenContent.kt
@@ -36,7 +36,6 @@ import com.mercadopago.sdk.android.components.MPAmountData
 import com.mercadopago.sdk.android.components.MPFixedFooter
 import com.mercadopago.sdk.android.components.MPFixedFooterButtonData
 import com.mercadopago.sdk.android.components.MPHeader
-import com.mercadopago.sdk.android.components.MPHeaderType
 import com.mercadopago.sdk.android.components.MPMessage
 import com.mercadopago.sdk.android.components.MPMessageType
 import com.mercadopago.sdk.android.components.MPPopover
@@ -121,7 +120,6 @@ internal fun CardPaymentScreenContent(
                 modifier = Modifier.fillMaxSize(),
                 title = "Preencha os dados do\ncartão",
                 onBackClick = onBackClick,
-                headerType = MPHeaderType.ScrollOff,
             ) {
                 var containerBounds by remember { mutableStateOf(Rect.Zero) }
                 var securityCodeBounds by remember { mutableStateOf(Rect.Zero) }

--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoAndesTheme
@@ -124,7 +123,10 @@ private fun MPHeaderScrollOffContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(MercadoPagoAndesTheme.spacing.paddings.xtiny)
-                    .padding(top = MercadoPagoAndesTheme.spacing.gap.medium + MercadoPagoAndesTheme.spacing.paddings.xtiny * 2)
+                    .padding(
+                        top = MercadoPagoAndesTheme.spacing.gap.medium +
+                            MercadoPagoAndesTheme.spacing.paddings.xtiny * 2,
+                    )
                     .onGloballyPositioned { coordinates ->
                         titleBlockHeightPx = coordinates.size.height.toFloat()
                     },

--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
@@ -155,13 +155,17 @@ private fun MPHeaderScrollOffContent(
             HeaderBackButton {
                 onBackClick.invoke()
             }
-            MPText(
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .alpha(progress),
-                text = title,
-                style = MercadoPagoAndesTheme.typography.heading.default.medium.copy(textAlign = TextAlign.Center),
-            )
+                contentAlignment = Alignment.Center,
+            ) {
+                MPText(
+                    text = title,
+                    style = MercadoPagoAndesTheme.typography.heading.default.medium,
+                )
+            }
         }
     }
 }
@@ -192,21 +196,32 @@ private fun MPHeaderSingleLayoutContent(
                     HeaderBackButton {
                         onBackClick.invoke()
                     }
-                    MPText(
+                    Box(
                         modifier = Modifier.fillMaxWidth(),
-                        text = title,
-                        style = MercadoPagoAndesTheme.typography.heading.default.medium.copy(textAlign = TextAlign.Center),
-                    )
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        MPText(
+                            text = title,
+                            style = MercadoPagoAndesTheme.typography.heading.default.medium,
+                        )
+                    }
                 }
             }
             MPHeaderType.TittleLeft -> {
                 Column(
-                    modifier = Modifier.padding(MercadoPagoAndesTheme.spacing.paddings.xtiny),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(MercadoPagoAndesTheme.spacing.paddings.xtiny),
                 ) {
-                    MPText(
-                        text = title,
-                        style = MercadoPagoAndesTheme.typography.heading.default.medium,
-                    )
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        MPText(
+                            text = title,
+                            style = MercadoPagoAndesTheme.typography.heading.default.medium,
+                        )
+                    }
                 }
             }
             MPHeaderType.ScrollOff -> { }
@@ -271,7 +286,7 @@ private fun MPHeaderScrollOffPreview() {
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
             ) {
-                repeat(5) { index ->
+                repeat(20) { index ->
                     MPText(
                         text = "Item $index",
                         style = MercadoPagoAndesTheme.typography.body.default.medium,

--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
@@ -35,73 +35,24 @@ import com.mercadopago.sdk.android.foundation.theme.MercadoPagoTheme
 /**
  * A header component that provides different layout styles for page headers.
  *
- * The component supports three different header types through [headerType]:
- * - [MPHeaderType.ScrollOff]: The expanded header (back button, large title, optional subtitle) is placed
- *   above the content and scrolls up with it. A collapsed bar (back + medium title) is shown as an overlay
- *   at the top, fading from transparent to fully visible as the user scrolls. When using ScrollOff, do not
- *   apply [androidx.compose.foundation.verticalScroll] to the content passed in [content]; the scroll is
- *   owned by this component.
- * - [MPHeaderType.ScrollOn]: Displays back button and medium title in a fixed row layout.
- * - [MPHeaderType.TittleLeft]: Displays only medium title without back button.
+ * The component supports  expanded header (back button, large title, optional subtitle) is placed
+ *  above the content and scrolls up with it. A collapsed bar (back + medium title) is shown as an overlay
+ *  at the top, fading from transparent to fully visible as the user scrolls.
  *
  * @param modifier Modifier to be applied to the header container.
  * @param title The title text displayed in the header. Required parameter.
  * @param subtitle Optional subtitle text displayed below the title.
- * Only visible when [headerType] is [MPHeaderType.ScrollOff].
  * @param onBackClick Callback invoked when the back button is clicked.
- * Only active when [headerType] is [MPHeaderType.ScrollOff] or [MPHeaderType.ScrollOn].
- * @param headerType The type of header layout to display. Defaults to [MPHeaderType.ScrollOn].
  * @param content The composable content to display below the header. When [headerType] is [MPHeaderType.ScrollOff],
  * this content is placed inside the same scroll as the expanded header; do not add verticalScroll to it.
  */
+@Suppress("LongMethod")
 @Composable
 fun MPHeader(
     modifier: Modifier = Modifier,
     title: String,
     subtitle: String = "",
     onBackClick: () -> Unit = {},
-    headerType: MPHeaderType = MPHeaderType.ScrollOn,
-    content: @Composable () -> Unit,
-) {
-    when (headerType) {
-        MPHeaderType.ScrollOff -> {
-            MPHeaderScrollOffContent(
-                modifier = modifier,
-                title = title,
-                subtitle = subtitle,
-                onBackClick = onBackClick,
-                content = content,
-            )
-        }
-        MPHeaderType.ScrollOn -> {
-            MPHeaderSingleLayoutContent(
-                modifier = modifier,
-                headerType = headerType,
-                title = title,
-                subtitle = subtitle,
-                onBackClick = onBackClick,
-                content = content,
-            )
-        }
-        MPHeaderType.TittleLeft -> {
-            MPHeaderSingleLayoutContent(
-                modifier = modifier,
-                headerType = headerType,
-                title = title,
-                subtitle = subtitle,
-                onBackClick = onBackClick,
-                content = content,
-            )
-        }
-    }
-}
-
-@Composable
-private fun MPHeaderScrollOffContent(
-    modifier: Modifier,
-    title: String,
-    subtitle: String,
-    onBackClick: () -> Unit,
     content: @Composable () -> Unit,
 ) {
     val scrollState = rememberScrollState()
@@ -173,66 +124,6 @@ private fun MPHeaderScrollOffContent(
 }
 
 @Composable
-private fun MPHeaderSingleLayoutContent(
-    modifier: Modifier,
-    headerType: MPHeaderType,
-    title: String,
-    subtitle: String,
-    onBackClick: () -> Unit,
-    content: @Composable () -> Unit,
-) {
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(color = MercadoPagoAndesTheme.color.background.primary),
-    ) {
-        when (headerType) {
-            MPHeaderType.ScrollOn -> {
-                Row(
-                    modifier = Modifier
-                        .padding(MercadoPagoAndesTheme.spacing.paddings.xtiny)
-                        .fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    HeaderBackButton {
-                        onBackClick.invoke()
-                    }
-                    Box(
-                        modifier = Modifier.fillMaxWidth(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        MPText(
-                            text = title,
-                            style = MercadoPagoAndesTheme.typography.heading.default.medium,
-                        )
-                    }
-                }
-            }
-            MPHeaderType.TittleLeft -> {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(MercadoPagoAndesTheme.spacing.paddings.xtiny),
-                ) {
-                    Box(
-                        modifier = Modifier.fillMaxWidth(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        MPText(
-                            text = title,
-                            style = MercadoPagoAndesTheme.typography.heading.default.medium,
-                        )
-                    }
-                }
-            }
-            MPHeaderType.ScrollOff -> { }
-        }
-        content.invoke()
-    }
-}
-
-@Composable
 private fun HeaderBackButton(
     modifier: Modifier = Modifier,
     defaults: MPHeaderDefaults = getMPHeaderDefaults(),
@@ -259,20 +150,6 @@ private fun HeaderBackButton(
     }
 }
 
-/**
- * Enum representing the different types of header layouts.
- */
-enum class MPHeaderType {
-    /** Header with back button, large title, and subtitle displayed in a column layout. */
-    ScrollOff,
-
-    /** Header with back button and medium title displayed in a row layout.*/
-    ScrollOn,
-
-    /** Header with only medium title, no back button.*/
-    TittleLeft,
-}
-
 @Preview(name = "MPHeader ScrollOff", group = "HEADER")
 @Composable
 private fun MPHeaderScrollOffPreview() {
@@ -281,14 +158,13 @@ private fun MPHeaderScrollOffPreview() {
             title = "Page Title",
             subtitle = "Label",
             onBackClick = {},
-            headerType = MPHeaderType.ScrollOff,
         ) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
             ) {
-                repeat(20) { index ->
+                repeat(Int.MAX_VALUE) { index ->
                     MPText(
                         text = "Item $index",
                         style = MercadoPagoAndesTheme.typography.body.default.medium,
@@ -310,12 +186,11 @@ private fun MPHeaderScrollOnPreview() {
         MPHeader(
             title = "Page Title",
             onBackClick = {},
-            headerType = MPHeaderType.ScrollOn,
         ) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
             ) {
-                items(20) { index ->
+                items(Int.MAX_VALUE) { index ->
                     MPText(
                         text = "Item $index",
                         style = MercadoPagoAndesTheme.typography.body.default.medium,

--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoAndesTheme
@@ -83,7 +84,9 @@ fun MPHeader(
 
             MPHeaderType.ScrollOn -> {
                 Row(
-                    modifier = Modifier.padding(MercadoPagoAndesTheme.spacing.paddings.xtiny),
+                    modifier = Modifier
+                        .padding(MercadoPagoAndesTheme.spacing.paddings.xtiny)
+                        .fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -92,8 +95,9 @@ fun MPHeader(
                     }
                     Spacer(modifier = Modifier.size(MercadoPagoAndesTheme.spacing.paddings.xmicro))
                     MPText(
+                        modifier = Modifier.fillMaxWidth(),
                         text = title,
-                        style = MercadoPagoAndesTheme.typography.heading.default.medium,
+                        style = MercadoPagoAndesTheme.typography.heading.default.medium.copy(textAlign = TextAlign.Center),
                     )
                 }
             }

--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
@@ -29,9 +29,9 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.mercadopago.sdk.android.components.extensions.scrollProgressRatio
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoAndesTheme
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoTheme
-import com.mercadopago.sdk.android.components.extensions.scrollProgressRatio
 
 /**
  * A header component that provides different layout styles for page headers.
@@ -63,33 +63,12 @@ fun MPHeader(
         modifier = modifier
             .background(color = MercadoPagoAndesTheme.color.background.primary),
     ) {
-        Column(
-            modifier = Modifier.verticalScroll(scrollState),
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(MercadoPagoAndesTheme.spacing.paddings.xtiny)
-                    .padding(
-                        top = MercadoPagoAndesTheme.spacing.gap.medium +
-                            MercadoPagoAndesTheme.spacing.paddings.xtiny * 2,
-                    )
-                    .onGloballyPositioned { coordinates ->
-                        titleBlockHeightPx = coordinates.size.height.toFloat()
-                    },
-            ) {
-                MPText(
-                    text = title,
-                    style = MercadoPagoAndesTheme.typography.heading.default.huge,
-                )
-                if (subtitle.isNotBlank()) {
-                    Spacer(modifier = Modifier.size(MercadoPagoAndesTheme.spacing.paddings.xmicro))
-                    MPText(
-                        text = subtitle,
-                        style = MercadoPagoAndesTheme.typography.body.default.medium,
-                    )
-                }
-            }
+        Column(modifier = Modifier.verticalScroll(scrollState)) {
+            MPHeaderExpandedTitle(
+                title = title,
+                subtitle = subtitle,
+                onHeightMeasured = { titleBlockHeightPx = it },
+            )
             content.invoke()
         }
         Row(
@@ -101,21 +80,59 @@ fun MPHeader(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            HeaderBackButton {
-                onBackClick.invoke()
-            }
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .alpha(progress),
-                contentAlignment = Alignment.Center,
-            ) {
-                MPText(
-                    text = title,
-                    style = MercadoPagoAndesTheme.typography.heading.default.medium,
-                )
-            }
+            HeaderBackButton(onClick = onBackClick)
+            MPHeaderCollapsedTitle(title = title, progress = progress)
         }
+    }
+}
+
+@Composable
+private fun MPHeaderExpandedTitle(
+    title: String,
+    subtitle: String,
+    onHeightMeasured: (Float) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(MercadoPagoAndesTheme.spacing.paddings.xtiny)
+            .padding(
+                top = MercadoPagoAndesTheme.spacing.gap.medium +
+                    MercadoPagoAndesTheme.spacing.paddings.xtiny * 2,
+            )
+            .onGloballyPositioned { coordinates ->
+                onHeightMeasured(coordinates.size.height.toFloat())
+            },
+    ) {
+        MPText(
+            text = title,
+            style = MercadoPagoAndesTheme.typography.heading.default.huge,
+        )
+        if (subtitle.isNotBlank()) {
+            Spacer(modifier = Modifier.size(MercadoPagoAndesTheme.spacing.paddings.xmicro))
+            MPText(
+                text = subtitle,
+                style = MercadoPagoAndesTheme.typography.body.default.medium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MPHeaderCollapsedTitle(
+    title: String,
+    progress: Float,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .alpha(progress),
+        contentAlignment = Alignment.Center,
+    ) {
+        MPText(
+            text = title,
+            style = MercadoPagoAndesTheme.typography.heading.default.medium,
+        )
     }
 }
 
@@ -146,6 +163,42 @@ private fun HeaderBackButton(
     }
 }
 
+@Composable
+private fun MPHeaderScrollOffPreviewContent() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+    ) {
+        repeat(Int.SIZE_BITS) { index ->
+            MPText(
+                text = "Item $index",
+                style = MercadoPagoAndesTheme.typography.body.default.medium,
+                color = MercadoPagoAndesTheme.color.text.primary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun MPHeaderScrollOnPreviewContent() {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(Int.SIZE_BITS) { index ->
+            MPText(
+                text = "Item $index",
+                style = MercadoPagoAndesTheme.typography.body.default.medium,
+                color = MercadoPagoAndesTheme.color.text.primary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            )
+        }
+    }
+}
+
 @Preview(name = "MPHeader ScrollOff", group = "HEADER")
 @Composable
 private fun MPHeaderScrollOffPreview() {
@@ -154,24 +207,8 @@ private fun MPHeaderScrollOffPreview() {
             title = "Page Title",
             subtitle = "Label",
             onBackClick = {},
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-            ) {
-                repeat(20) { index ->
-                    MPText(
-                        text = "Item $index",
-                        style = MercadoPagoAndesTheme.typography.body.default.medium,
-                        color = MercadoPagoAndesTheme.color.text.primary,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                    )
-                }
-            }
-        }
+            content = { MPHeaderScrollOffPreviewContent() },
+        )
     }
 }
 
@@ -182,21 +219,7 @@ private fun MPHeaderScrollOnPreview() {
         MPHeader(
             title = "Page Title",
             onBackClick = {},
-        ) {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-            ) {
-                items(20) { index ->
-                    MPText(
-                        text = "Item $index",
-                        style = MercadoPagoAndesTheme.typography.body.default.medium,
-                        color = MercadoPagoAndesTheme.color.text.primary,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                    )
-                }
-            }
-        }
+            content = { MPHeaderScrollOnPreviewContent() },
+        )
     }
 }

--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
@@ -106,10 +106,10 @@ private fun MPHeaderScrollOffContent(
     content: @Composable () -> Unit,
 ) {
     val scrollState = rememberScrollState()
-    var scrollOffHeightPx by remember { mutableStateOf(0f) }
+    var titleBlockHeightPx by remember { mutableStateOf(0f) }
     val scrollOffset = scrollState.value.toFloat()
-    val progress = if (scrollOffHeightPx > 0) {
-        (scrollOffset / scrollOffHeightPx).coerceIn(0f, 1f)
+    val progress = if (titleBlockHeightPx > 0) {
+        (scrollOffset / titleBlockHeightPx).coerceIn(0f, 1f)
     } else {
         0f
     }
@@ -124,14 +124,11 @@ private fun MPHeaderScrollOffContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(MercadoPagoAndesTheme.spacing.paddings.xtiny)
+                    .padding(top = MercadoPagoAndesTheme.spacing.gap.medium + MercadoPagoAndesTheme.spacing.paddings.xtiny * 2)
                     .onGloballyPositioned { coordinates ->
-                        scrollOffHeightPx = coordinates.size.height.toFloat()
+                        titleBlockHeightPx = coordinates.size.height.toFloat()
                     },
             ) {
-                HeaderBackButton {
-                    onBackClick.invoke()
-                }
-                Spacer(modifier = Modifier.size(MercadoPagoAndesTheme.spacing.paddings.tiny))
                 MPText(
                     text = title,
                     style = MercadoPagoAndesTheme.typography.heading.default.huge,
@@ -150,7 +147,6 @@ private fun MPHeaderScrollOffContent(
             modifier = Modifier
                 .align(Alignment.TopStart)
                 .fillMaxWidth()
-                .alpha(progress)
                 .background(color = MercadoPagoAndesTheme.color.background.primary)
                 .padding(MercadoPagoAndesTheme.spacing.paddings.xtiny),
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -160,7 +156,9 @@ private fun MPHeaderScrollOffContent(
                 onBackClick.invoke()
             }
             MPText(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .alpha(progress),
                 text = title,
                 style = MercadoPagoAndesTheme.typography.heading.default.medium.copy(textAlign = TextAlign.Center),
             )

--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
@@ -13,12 +13,19 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -30,8 +37,12 @@ import com.mercadopago.sdk.android.foundation.theme.MercadoPagoTheme
  * A header component that provides different layout styles for page headers.
  *
  * The component supports three different header types through [headerType]:
- * - [MPHeaderType.ScrollOff]: Displays back button, large title, and optional subtitle in a column layout.
- * - [MPHeaderType.ScrollOn]: Displays back button and medium title in a row layout.
+ * - [MPHeaderType.ScrollOff]: The expanded header (back button, large title, optional subtitle) is placed
+ *   above the content and scrolls up with it. A collapsed bar (back + medium title) is shown as an overlay
+ *   at the top, fading from transparent to fully visible as the user scrolls. When using ScrollOff, do not
+ *   apply [androidx.compose.foundation.verticalScroll] to the content passed in [content]; the scroll is
+ *   owned by this component.
+ * - [MPHeaderType.ScrollOn]: Displays back button and medium title in a fixed row layout.
  * - [MPHeaderType.TittleLeft]: Displays only medium title without back button.
  *
  * @param modifier Modifier to be applied to the header container.
@@ -40,8 +51,9 @@ import com.mercadopago.sdk.android.foundation.theme.MercadoPagoTheme
  * Only visible when [headerType] is [MPHeaderType.ScrollOff].
  * @param onBackClick Callback invoked when the back button is clicked.
  * Only active when [headerType] is [MPHeaderType.ScrollOff] or [MPHeaderType.ScrollOn].
- * @param headerType The type of header layout to display. Defaults to [MPHeaderType.ScrollOff].
- * @param content The composable content to display below the header.
+ * @param headerType The type of header layout to display. Defaults to [MPHeaderType.ScrollOn].
+ * @param content The composable content to display below the header. When [headerType] is [MPHeaderType.ScrollOff],
+ * this content is placed inside the same scroll as the expanded header; do not add verticalScroll to it.
  */
 @Composable
 fun MPHeader(
@@ -49,39 +61,128 @@ fun MPHeader(
     title: String,
     subtitle: String = "",
     onBackClick: () -> Unit = {},
-    headerType: MPHeaderType = MPHeaderType.ScrollOff,
+    headerType: MPHeaderType = MPHeaderType.ScrollOn,
     content: @Composable () -> Unit,
 ) {
-    val defaults = getMPHeaderDefaults()
+    when (headerType) {
+        MPHeaderType.ScrollOff -> {
+            MPHeaderScrollOffContent(
+                modifier = modifier,
+                title = title,
+                subtitle = subtitle,
+                onBackClick = onBackClick,
+                content = content,
+            )
+        }
+        MPHeaderType.ScrollOn -> {
+            MPHeaderSingleLayoutContent(
+                modifier = modifier,
+                headerType = headerType,
+                title = title,
+                subtitle = subtitle,
+                onBackClick = onBackClick,
+                content = content,
+            )
+        }
+        MPHeaderType.TittleLeft -> {
+            MPHeaderSingleLayoutContent(
+                modifier = modifier,
+                headerType = headerType,
+                title = title,
+                subtitle = subtitle,
+                onBackClick = onBackClick,
+                content = content,
+            )
+        }
+    }
+}
 
+@Composable
+private fun MPHeaderScrollOffContent(
+    modifier: Modifier,
+    title: String,
+    subtitle: String,
+    onBackClick: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    var scrollOffHeightPx by remember { mutableStateOf(0f) }
+    val scrollOffset = scrollState.value.toFloat()
+    val progress = if (scrollOffHeightPx > 0) {
+        (scrollOffset / scrollOffHeightPx).coerceIn(0f, 1f)
+    } else {
+        0f
+    }
+    Box(
+        modifier = modifier
+            .background(color = MercadoPagoAndesTheme.color.background.primary),
+    ) {
+        Column(
+            modifier = Modifier.verticalScroll(scrollState),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(MercadoPagoAndesTheme.spacing.paddings.xtiny)
+                    .onGloballyPositioned { coordinates ->
+                        scrollOffHeightPx = coordinates.size.height.toFloat()
+                    },
+            ) {
+                HeaderBackButton {
+                    onBackClick.invoke()
+                }
+                Spacer(modifier = Modifier.size(MercadoPagoAndesTheme.spacing.paddings.tiny))
+                MPText(
+                    text = title,
+                    style = MercadoPagoAndesTheme.typography.heading.default.huge,
+                )
+                if (subtitle.isNotBlank()) {
+                    Spacer(modifier = Modifier.size(MercadoPagoAndesTheme.spacing.paddings.xmicro))
+                    MPText(
+                        text = subtitle,
+                        style = MercadoPagoAndesTheme.typography.body.default.medium,
+                    )
+                }
+            }
+            content.invoke()
+        }
+        Row(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .fillMaxWidth()
+                .alpha(progress)
+                .background(color = MercadoPagoAndesTheme.color.background.primary)
+                .padding(MercadoPagoAndesTheme.spacing.paddings.xtiny),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            HeaderBackButton {
+                onBackClick.invoke()
+            }
+            MPText(
+                modifier = Modifier.fillMaxWidth(),
+                text = title,
+                style = MercadoPagoAndesTheme.typography.heading.default.medium.copy(textAlign = TextAlign.Center),
+            )
+        }
+    }
+}
+
+@Composable
+private fun MPHeaderSingleLayoutContent(
+    modifier: Modifier,
+    headerType: MPHeaderType,
+    title: String,
+    subtitle: String,
+    onBackClick: () -> Unit,
+    content: @Composable () -> Unit,
+) {
     Column(
         modifier = modifier
             .fillMaxSize()
             .background(color = MercadoPagoAndesTheme.color.background.primary),
     ) {
         when (headerType) {
-            MPHeaderType.ScrollOff -> {
-                Column(
-                    modifier = Modifier.padding(MercadoPagoAndesTheme.spacing.paddings.xtiny),
-                ) {
-                    HeaderBackButton {
-                        onBackClick.invoke()
-                    }
-                    Spacer(modifier = Modifier.size(MercadoPagoAndesTheme.spacing.paddings.tiny))
-                    MPText(
-                        text = title,
-                        style = MercadoPagoAndesTheme.typography.heading.default.huge,
-                    )
-                    if (subtitle.isNotBlank()) {
-                        Spacer(modifier = Modifier.size(MercadoPagoAndesTheme.spacing.paddings.xmicro))
-                        MPText(
-                            text = subtitle,
-                            style = MercadoPagoAndesTheme.typography.body.default.medium,
-                        )
-                    }
-                }
-            }
-
             MPHeaderType.ScrollOn -> {
                 Row(
                     modifier = Modifier
@@ -93,7 +194,6 @@ fun MPHeader(
                     HeaderBackButton {
                         onBackClick.invoke()
                     }
-                    Spacer(modifier = Modifier.size(MercadoPagoAndesTheme.spacing.paddings.xmicro))
                     MPText(
                         modifier = Modifier.fillMaxWidth(),
                         text = title,
@@ -101,7 +201,6 @@ fun MPHeader(
                     )
                 }
             }
-
             MPHeaderType.TittleLeft -> {
                 Column(
                     modifier = Modifier.padding(MercadoPagoAndesTheme.spacing.paddings.xtiny),
@@ -112,8 +211,8 @@ fun MPHeader(
                     )
                 }
             }
+            MPHeaderType.ScrollOff -> { }
         }
-
         content.invoke()
     }
 }
@@ -159,19 +258,49 @@ enum class MPHeaderType {
     TittleLeft,
 }
 
-@Preview(name = "MPHeader Preview", group = "HEADER")
+@Preview(name = "MPHeader ScrollOff", group = "HEADER")
 @Composable
-private fun MPHeaderPreview() {
+private fun MPHeaderScrollOffPreview() {
     MercadoPagoTheme {
         MPHeader(
             title = "Page Title",
             subtitle = "Label",
             onBackClick = {},
+            headerType = MPHeaderType.ScrollOff,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            ) {
+                repeat(5) { index ->
+                    MPText(
+                        text = "Item $index",
+                        style = MercadoPagoAndesTheme.typography.body.default.medium,
+                        color = MercadoPagoAndesTheme.color.text.primary,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(name = "MPHeader ScrollOn", group = "HEADER")
+@Composable
+private fun MPHeaderScrollOnPreview() {
+    MercadoPagoTheme {
+        MPHeader(
+            title = "Page Title",
+            onBackClick = {},
+            headerType = MPHeaderType.ScrollOn,
         ) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
             ) {
-                items(Int.MAX_VALUE) { index ->
+                items(20) { index ->
                     MPText(
                         text = "Item $index",
                         style = MercadoPagoAndesTheme.typography.body.default.medium,

--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
@@ -18,7 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -31,6 +31,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoAndesTheme
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoTheme
+import com.mercadopago.sdk.android.components.extensions.scrollProgressRatio
 
 /**
  * A header component that provides different layout styles for page headers.
@@ -43,10 +44,9 @@ import com.mercadopago.sdk.android.foundation.theme.MercadoPagoTheme
  * @param title The title text displayed in the header. Required parameter.
  * @param subtitle Optional subtitle text displayed below the title.
  * @param onBackClick Callback invoked when the back button is clicked.
- * @param content The composable content to display below the header. When [headerType] is [MPHeaderType.ScrollOff],
+ * @param content The composable content to display below the header.
  * this content is placed inside the same scroll as the expanded header; do not add verticalScroll to it.
  */
-@Suppress("LongMethod")
 @Composable
 fun MPHeader(
     modifier: Modifier = Modifier,
@@ -56,13 +56,9 @@ fun MPHeader(
     content: @Composable () -> Unit,
 ) {
     val scrollState = rememberScrollState()
-    var titleBlockHeightPx by remember { mutableStateOf(0f) }
+    var titleBlockHeightPx by remember { mutableFloatStateOf(0f) }
     val scrollOffset = scrollState.value.toFloat()
-    val progress = if (titleBlockHeightPx > 0) {
-        (scrollOffset / titleBlockHeightPx).coerceIn(0f, 1f)
-    } else {
-        0f
-    }
+    val progress = scrollOffset.scrollProgressRatio(titleBlockHeightPx)
     Box(
         modifier = modifier
             .background(color = MercadoPagoAndesTheme.color.background.primary),
@@ -164,7 +160,7 @@ private fun MPHeaderScrollOffPreview() {
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
             ) {
-                repeat(Int.MAX_VALUE) { index ->
+                repeat(20) { index ->
                     MPText(
                         text = "Item $index",
                         style = MercadoPagoAndesTheme.typography.body.default.medium,
@@ -190,7 +186,7 @@ private fun MPHeaderScrollOnPreview() {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
             ) {
-                items(Int.MAX_VALUE) { index ->
+                items(20) { index ->
                     MPText(
                         text = "Item $index",
                         style = MercadoPagoAndesTheme.typography.body.default.medium,

--- a/components/src/main/java/com/mercadopago/sdk/android/components/extensions/FloatExt.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/extensions/FloatExt.kt
@@ -1,4 +1,5 @@
 package com.mercadopago.sdk.android.components.extensions
 
-fun Float.scrollProgressRatio(divisor: Float): Float =
-    if (divisor > 0) (this / divisor).coerceIn(0f, 1f) else 0f
+internal fun Float.scrollProgressRatio(
+    divisor: Float,
+): Float = if (divisor > 0) (this / divisor).coerceIn(0f, 1f) else 0f

--- a/components/src/main/java/com/mercadopago/sdk/android/components/extensions/FloatExt.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/extensions/FloatExt.kt
@@ -1,0 +1,4 @@
+package com.mercadopago.sdk.android.components.extensions
+
+fun Float.scrollProgressRatio(divisor: Float): Float =
+    if (divisor > 0) (this / divisor).coerceIn(0f, 1f) else 0f


### PR DESCRIPTION
# Pull Request
Component Header
## Ticket or Issue link
3566

## Description
Implements and refines the SDK Header component with Andes design tokens, scroll-driven expand/collapse behavior, and integration with the card payment screen.

- **MPHeader**: Two states — **expanded** (back + large title + optional subtitle, scrolls with content); **collapsed** (fixed top bar, back + medium title, alpha driven by `scrollProgressRatio`).
- **MPHeaderDefaults**: Defaults for colors, spacing, shape, typography; wired to `MercadoPagoAndesTheme`.
- Added `ic_arrow_left.xml` for back action.

## Checklist
- [ ] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [ ] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)

| Expanded | On animate | collapsed |
| :--- | :---: | ---: |
|<img width="257" height="100" alt="Captura de Tela 2026-02-13 às 16 41 07" src="https://github.com/user-attachments/assets/671e81d1-8829-4a32-87a1-c98705e90de9" /> | <img width="340" height="90" alt="Captura de Tela 2026-02-13 às 16 41 25" src="https://github.com/user-attachments/assets/b84fd895-cd83-4861-aaa0-ae97dceb2a4e" />| <img width="334" height="94" alt="Captura de Tela 2026-02-13 às 16 42 07" src="https://github.com/user-attachments/assets/196ee809-90e5-4fa3-ad26-6a032f633447" /> |

