### PR TITLE
[3735] Fix: Remove Saver for PCI DSS compliance

### DIFF
--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/pcitextfield/PCIFieldState.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/pcitextfield/PCIFieldState.kt
@@ -4,8 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 
 /**
@@ -13,23 +12,22 @@ import androidx.compose.runtime.setValue
  * This class manages the state of secure input fields that handle sensitive payment information,
  * ensuring compliance with Payment Card Industry (PCI) security standards.
  *
- * The state is preserved across configuration changes and process death using Compose's
- * state restoration system. It provides a secure way to handle sensitive payment data
- * while maintaining state consistency throughout the payment flow.
+ * **Security note**: PCI field data (card number, CVV, expiration date) is intentionally NOT
+ * persisted to the Android Bundle or disk. This means data will be lost on process death.
+ * This is the expected behavior to comply with PCI DSS — sensitive card data must never be
+ * written to persistent storage.
  *
- * Example:
+ * To preserve PCI field state across configuration changes (e.g., screen rotation),
+ * host the [PCIFieldState] instances in your ViewModel:
+ *
  * ```kotlin
- * // Create a PCI field state
- * val state = rememberPCIFieldState()
- *
- * // Use the state in a PCI-compliant text field
- * CardNumberTextField(
- *     state = state,
- *     onEvent = { event ->
- *         // Handle events
- *     }
- * )
+ * class PaymentViewModel : ViewModel() {
+ *     val cardNumberState = PCIFieldState.create()
+ *     val expirationDateState = PCIFieldState.create()
+ *     val securityCodeState = PCIFieldState.create()
+ * }
  * ```
+ *
  * @see rememberPCIFieldState
  */
 @Stable
@@ -43,57 +41,49 @@ class PCIFieldState internal constructor() {
     val isEmpty: Boolean
         get() = input.isEmpty()
 
-    /**
-     * Companion object providing state restoration functionality.
-     * This allows the PCI field state to be preserved across configuration changes
-     * and process death using Compose's state restoration system.
-     *
-     * The saver handles:
-     * - Saving the current input value
-     * - Restoring the state with the saved input value
-     * - Creating a new state instance if needed
-     */
+    /** Factory methods for creating [PCIFieldState] instances outside of a Composable context. */
     companion object {
-        internal val Saver: Saver<PCIFieldState, String> = Saver<PCIFieldState, String>(
-            save = { it.input },
-            restore = { restored ->
-                PCIFieldState().apply {
-                    input = restored
-                }
-            },
-        )
+        /**
+         * Creates a new [PCIFieldState] instance.
+         * Use this factory method when you need to create PCI field states outside of a Composable,
+         * for example in a ViewModel to survive configuration changes.
+         *
+         * ```kotlin
+         * class PaymentViewModel : ViewModel() {
+         *     val cardNumberState = PCIFieldState.create()
+         * }
+         * ```
+         */
+        fun create(): PCIFieldState = PCIFieldState()
     }
 }
 
 /**
- * Creates a new instance of PCIFieldState that persists across configuration changes.
- * This composable function should be used to create state holders for PCI-compliant
- * input fields in the payment form.
+ * Creates a new instance of [PCIFieldState] that is remembered across recompositions.
  *
- * The state is automatically preserved across:
- * - Configuration changes (e.g., screen rotation)
- * - Process death and recreation
- * - Navigation events
+ * **Important**: This state is NOT preserved across process death or configuration changes
+ * (e.g., screen rotation). This is intentional for PCI DSS compliance — sensitive card data
+ * (card number, CVV, expiration date) must never be serialized to Bundle or disk.
  *
- * Example:
+ * To preserve state across configuration changes, host [PCIFieldState] in your ViewModel instead:
+ *
  * ```kotlin
- * @Composable
- * fun PaymentForm() {
- *     val cardNumberState = rememberPCIFieldState()
- *     val expirationState = rememberPCIFieldState()
+ * class PaymentViewModel : ViewModel() {
+ *     val cardNumberState = PCIFieldState.create()
+ *     val expirationDateState = PCIFieldState.create()
+ *     val securityCodeState = PCIFieldState.create()
+ * }
  *
- *     Column {
- *         CardNumberTextField(state = cardNumberState)
- *         ExpirationDateTextField(state = expirationState)
- *     }
+ * @Composable
+ * fun PaymentForm(viewModel: PaymentViewModel) {
+ *     CardNumberTextField(state = viewModel.cardNumberState)
+ *     ExpirationDateTextField(state = viewModel.expirationDateState)
  * }
  * ```
  *
- * @return A new PCIFieldState instance that will be preserved across configuration changes
+ * @return A new [PCIFieldState] instance remembered for the current composition
  */
 @Composable
 fun rememberPCIFieldState(): PCIFieldState {
-    return rememberSaveable<PCIFieldState>(saver = PCIFieldState.Saver) {
-        PCIFieldState()
-    }
+    return remember { PCIFieldState() }
 }

--- a/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/expirationdatefield/ExpirationDateTextFieldTest.kt
+++ b/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/expirationdatefield/ExpirationDateTextFieldTest.kt
@@ -143,10 +143,9 @@ internal class ExpirationDateTextFieldTest {
     }
 
     @Test
-    fun `when user types input and configuration is changed Then input should be restored`() {
+    fun `when user types input and configuration is changed Then input should be cleared for PCI compliance`() {
         // Given
         val input = "123"
-        val maskedInput = "12/3"
         val stateRestorationTester = StateRestorationTester(composeTestRule)
 
         // When
@@ -154,19 +153,18 @@ internal class ExpirationDateTextFieldTest {
             createExpirationDateField(stateRestorationTester = stateRestorationTester)
             performTextInput(input)
 
-            // Perform configuration change
+            // Perform configuration change (simulates process death + Bundle restore)
             stateRestorationTester.emulateSavedInstanceStateRestore()
 
-            // Then
-            assetTextVisualTransformation(input, maskedInput)
+            // Then - PCI data must NOT survive serialization to Bundle
+            assetTextVisualTransformation("", "")
         }
     }
 
     @Test
-    fun `when user types text input and configuration is changed Then input should be restored`() {
+    fun `when user types text input and configuration is changed Then input should be cleared for PCI compliance`() {
         // Given
         val input = "123"
-        val maskedInput = "12/3"
         val stateRestorationTester = StateRestorationTester(composeTestRule)
 
         // When
@@ -174,11 +172,11 @@ internal class ExpirationDateTextFieldTest {
             createExpirationDateField(stateRestorationTester = stateRestorationTester)
             performTextInput(input)
 
-            // Perform configuration change
+            // Perform configuration change (simulates process death + Bundle restore)
             stateRestorationTester.emulateSavedInstanceStateRestore()
 
-            // Then
-            assetTextVisualTransformation(input, maskedInput)
+            // Then - PCI data must NOT survive serialization to Bundle
+            assetTextVisualTransformation("", "")
         }
     }
 }

--- a/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/pcitextfield/PCIFieldStateTest.kt
+++ b/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/pcitextfield/PCIFieldStateTest.kt
@@ -1,0 +1,43 @@
+package com.mercadopago.sdk.android.coremethods.ui.components.textfield.pcitextfield
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PCIFieldStateTest {
+    @Test
+    fun `PCIFieldState initializes with empty input`() {
+        val state = PCIFieldState()
+        assertEquals("", state.input)
+    }
+
+    @Test
+    fun `PCIFieldState input can be set and read`() {
+        val state = PCIFieldState()
+        state.input = "4111111111111111"
+        assertEquals("4111111111111111", state.input)
+    }
+
+    @Test
+    fun `isEmpty returns true when input is empty`() {
+        val state = PCIFieldState()
+        assertTrue(state.isEmpty)
+    }
+
+    @Test
+    fun `isEmpty returns false when input has content`() {
+        val state = PCIFieldState()
+        state.input = "123"
+        assertFalse(state.isEmpty)
+    }
+
+    @Test
+    fun `PCIFieldState does not contain Saver companion`() {
+        val companionMembers = PCIFieldState.Companion::class.members.map { it.name }
+        assertFalse(
+            companionMembers.any { it.contains("Saver", ignoreCase = true) },
+            "PCIFieldState should not contain a Saver to prevent PCI data serialization to Bundle/disk",
+        )
+    }
+}

--- a/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/pcitextfield/PCITextFieldTest.kt
+++ b/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/pcitextfield/PCITextFieldTest.kt
@@ -88,7 +88,7 @@ internal class PCITextFieldTest {
     @Test
     fun `when field has decoration box Then text should be visible`() {
         // Given
-        var input = "1234"
+        val input = "1234"
         val title = "Card Number Field"
 
         // When
@@ -111,9 +111,9 @@ internal class PCITextFieldTest {
     }
 
     @Test
-    fun `when user types input and configuration is changed Then input should be restored`() {
+    fun `when user types input and configuration is changed Then input should be cleared for PCI compliance`() {
         // Given
-        var input = "1234"
+        val input = "1234"
         val stateRestorationTester = StateRestorationTester(composeTestRule)
 
         // When
@@ -121,18 +121,18 @@ internal class PCITextFieldTest {
             createTextField(stateRestorationTester = stateRestorationTester)
             performTextInput(input)
 
-            // Perform configuration change
+            // Perform configuration change (simulates process death + Bundle restore)
             stateRestorationTester.emulateSavedInstanceStateRestore()
 
-            // Then
-            assertTextInput(input)
+            // Then - PCI data must NOT survive serialization to Bundle
+            assertTextInput("")
         }
     }
 
     @Test
-    fun `when user types text input and configuration is changed Then input should be restored`() {
+    fun `when user types text input and configuration is changed Then input should be cleared for PCI compliance`() {
         // Given
-        var input = "abcdefg"
+        val input = "abcdefg"
         val stateRestorationTester = StateRestorationTester(composeTestRule)
 
         // When
@@ -140,11 +140,11 @@ internal class PCITextFieldTest {
             createTextField(stateRestorationTester = stateRestorationTester)
             performTextInput(input)
 
-            // Perform configuration change
+            // Perform configuration change (simulates process death + Bundle restore)
             stateRestorationTester.emulateSavedInstanceStateRestore()
 
-            // Then
-            assertTextInput(input)
+            // Then - PCI data must NOT survive serialization to Bundle
+            assertTextInput("")
         }
     }
 }

--- a/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/securityfield/SecurityCodeTextFieldTest.kt
+++ b/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/securityfield/SecurityCodeTextFieldTest.kt
@@ -130,7 +130,7 @@ internal class SecurityCodeTextFieldTest {
     @Test
     fun `when field has decoration box Then text should be visible`() {
         // Given
-        var input = "123"
+        val input = "123"
         val title = "Card Number Field"
 
         // When
@@ -153,9 +153,9 @@ internal class SecurityCodeTextFieldTest {
     }
 
     @Test
-    fun `when user types input and configuration is changed Then input should be restored`() {
+    fun `when user types input and configuration is changed Then input should be cleared for PCI compliance`() {
         // Given
-        var input = "123"
+        val input = "123"
         val stateRestorationTester = StateRestorationTester(composeTestRule)
 
         // When
@@ -163,18 +163,18 @@ internal class SecurityCodeTextFieldTest {
             createSecurityField(stateRestorationTester = stateRestorationTester)
             performTextInput(input)
 
-            // Perform configuration change
+            // Perform configuration change (simulates process death + Bundle restore)
             stateRestorationTester.emulateSavedInstanceStateRestore()
 
-            // Then
-            assertTextInput(input)
+            // Then - PCI data must NOT survive serialization to Bundle
+            assertTextInput("")
         }
     }
 
     @Test
-    fun `when user types text input and configuration is changed Then input should be restored`() {
+    fun `when user types text input and configuration is changed Then input should be cleared for PCI compliance`() {
         // Given
-        var input = "123"
+        val input = "123"
         val stateRestorationTester = StateRestorationTester(composeTestRule)
 
         // When
@@ -182,11 +182,11 @@ internal class SecurityCodeTextFieldTest {
             createSecurityField(stateRestorationTester = stateRestorationTester)
             performTextInput(input)
 
-            // Perform configuration change
+            // Perform configuration change (simulates process death + Bundle restore)
             stateRestorationTester.emulateSavedInstanceStateRestore()
 
-            // Then
-            assertTextInput(input)
+            // Then - PCI data must NOT survive serialization to Bundle
+            assertTextInput("")
         }
     }
 }

--- a/example/src/main/java/com/mercadopago/sdk/android/example/presentation/coremethods/PaymentExampleScreen.kt
+++ b/example/src/main/java/com/mercadopago/sdk/android/example/presentation/coremethods/PaymentExampleScreen.kt
@@ -32,7 +32,6 @@ import com.mercadopago.sdk.android.coremethods.domain.model.IdentificationType
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.cardnumber.CardNumberTextFieldEvent
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.expirationdate.ExpirationDateTextFieldEvent
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.pcitextfield.PCIFieldState
-import com.mercadopago.sdk.android.coremethods.ui.components.textfield.pcitextfield.rememberPCIFieldState
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.securitycode.SecurityCodeTextFieldEvent
 import com.mercadopago.sdk.android.example.R
 import com.mercadopago.sdk.android.example.data.model.Installment
@@ -56,9 +55,6 @@ internal fun PaymentExampleScreen(
     viewModel: PaymentScreenViewModel = koinViewModel(),
 ) {
     val viewState by viewModel.viewState.collectAsState()
-    val cardNumberState = rememberPCIFieldState()
-    val expirationDateState = rememberPCIFieldState()
-    val securityCodeState = rememberPCIFieldState()
 
     LaunchedEffect(key1 = true) {
         viewModel.getIdentificationTypes()
@@ -66,16 +62,10 @@ internal fun PaymentExampleScreen(
 
     PaymentExampleScreenContent(
         viewState = viewState,
-        cardNumberState = cardNumberState,
-        expirationDateState = expirationDateState,
-        securityCodeState = securityCodeState,
-        onGenerateCardToken = {
-            viewModel.generateToken(
-                cardNumberState = cardNumberState,
-                expirationDateState = expirationDateState,
-                securityCodeState = securityCodeState,
-            )
-        },
+        cardNumberState = viewModel.cardNumberPCIState,
+        expirationDateState = viewModel.expirationDatePCIState,
+        securityCodeState = viewModel.securityCodePCIState,
+        onGenerateCardToken = { viewModel.generateToken() },
         onExpirationDateEvent = viewModel::onExpirationDateEvent,
         onSecurityCodeEvent = viewModel::onSecurityCodeEvent,
         onCardNumberEvent = viewModel::onCardNumberEvent,

--- a/example/src/main/java/com/mercadopago/sdk/android/example/presentation/coremethods/PaymentScreenViewModel.kt
+++ b/example/src/main/java/com/mercadopago/sdk/android/example/presentation/coremethods/PaymentScreenViewModel.kt
@@ -43,6 +43,10 @@ internal class PaymentScreenViewModel(
     private val coreMethods: CoreMethods = MercadoPagoSDK.getInstance().coreMethods,
 ) : ViewModel() {
 
+    val cardNumberPCIState = PCIFieldState.create()
+    val expirationDatePCIState = PCIFieldState.create()
+    val securityCodePCIState = PCIFieldState.create()
+
     private val _viewState = MutableStateFlow(PaymentScreenViewState())
     val viewState: StateFlow<PaymentScreenViewState> = _viewState
 
@@ -51,9 +55,9 @@ internal class PaymentScreenViewModel(
         .create()
 
     fun generateToken(
-        cardNumberState: PCIFieldState,
-        expirationDateState: PCIFieldState,
-        securityCodeState: PCIFieldState,
+        cardNumberState: PCIFieldState = cardNumberPCIState,
+        expirationDateState: PCIFieldState = expirationDatePCIState,
+        securityCodeState: PCIFieldState = securityCodePCIState,
     ) {
         viewModelScope.launch {
             if (viewState.value.cardNumberState.length != viewState.value.cardNumberState.maxLength) {


### PR DESCRIPTION
# Pull Request
Remove Saver for PCI DSS compliance
## Ticket or Issue link
3735

## Description
- Replace rememberSaveable+Saver with remember in PCIFieldState — PCI data (card number, CVV, expiration) no longer  serialized to Android Bundle or disk
- Add PCIFieldState.create() factory for ViewModel usage outside Composables
- Update KDoc with PCI DSS compliance rationale and ViewModel pattern examples
- Add PCIFieldStateTest covering initialization, input, isEmpty, and Saver absence
- Update state-restoration tests to assert input is cleared after config change
- Host PCI states in PaymentScreenViewModel using PCIFieldState.create()
- Update PaymentExampleScreen to use ViewModel PCI states

## Checklist
- [ ] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [ ] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<!---
Provide videos or screenshots. You can change their size in the src
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>
-->
