### PR TITLE
[3824](Hotfix): Changed card_bin_length to 6

### DIFF
--- a/buildSrc/src/main/kotlin/com/mercadopago/sdk/android/BomConfig.kt
+++ b/buildSrc/src/main/kotlin/com/mercadopago/sdk/android/BomConfig.kt
@@ -8,5 +8,5 @@ package com.mercadopago.sdk.android
 object BomConfig {
 
     const val ARTIFACT_ID = "sdk-android-bom"
-    const val VERSION_NAME = "0.1.6"
+    const val VERSION_NAME = "0.1.7"
 }

--- a/buildSrc/src/main/kotlin/com/mercadopago/sdk/android/CoreMethodsSDKConfig.kt
+++ b/buildSrc/src/main/kotlin/com/mercadopago/sdk/android/CoreMethodsSDKConfig.kt
@@ -6,5 +6,5 @@
 object CoreMethodsSDKConfig {
 
     const val ARTIFACT_ID = "core-methods"
-    const val VERSION_NAME = "0.1.0"
+    const val VERSION_NAME = "0.1.1"
 }

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/data/remote/utils/Constants.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/data/remote/utils/Constants.kt
@@ -6,7 +6,6 @@ internal const val PRODUCT_ID: String = BuildConfig.CORE_METHODS_PRODUCT_ID
 
 internal const val EXPIRATION_YEAR_START = "20"
 internal const val EXPIRATION_YEAR_MIN_LENGTH = 2
-internal const val SECURITY_CODE_MIN_LENGTH = 3
 internal const val ERROR_SECURITY_CODE_MIN_LENGTH = "security code length cannot be smaller than tree"
 internal const val ERROR_EXPIRATION_DATE_EMPTY = "expiration date cannot be empty"
 internal const val ERROR_EXPIRATION_DATE_LENGTH = "expiration date length cannot be smaller than two"

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/data/remote/utils/Constants.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/data/remote/utils/Constants.kt
@@ -7,7 +7,7 @@ internal const val PRODUCT_ID: String = BuildConfig.CORE_METHODS_PRODUCT_ID
 internal const val EXPIRATION_YEAR_START = "20"
 internal const val EXPIRATION_YEAR_MIN_LENGTH = 2
 internal const val SECURITY_CODE_MIN_LENGTH = 3
-internal const val CARD_BIN_LENGTH = 3
+internal const val CARD_BIN_LENGTH = 8
 
 internal const val ERROR_SECURITY_CODE_MIN_LENGTH = "security code length cannot be smaller than tree"
 internal const val ERROR_EXPIRATION_DATE_EMPTY = "expiration date cannot be empty"

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/data/remote/utils/Constants.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/data/remote/utils/Constants.kt
@@ -7,7 +7,7 @@ internal const val PRODUCT_ID: String = BuildConfig.CORE_METHODS_PRODUCT_ID
 internal const val EXPIRATION_YEAR_START = "20"
 internal const val EXPIRATION_YEAR_MIN_LENGTH = 2
 internal const val SECURITY_CODE_MIN_LENGTH = 3
-internal const val CARD_BIN_LENGTH = 8
+internal const val CARD_BIN_LENGTH = 6
 
 internal const val ERROR_SECURITY_CODE_MIN_LENGTH = "security code length cannot be smaller than tree"
 internal const val ERROR_EXPIRATION_DATE_EMPTY = "expiration date cannot be empty"

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/data/remote/utils/Constants.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/data/remote/utils/Constants.kt
@@ -7,7 +7,7 @@ internal const val PRODUCT_ID: String = BuildConfig.CORE_METHODS_PRODUCT_ID
 internal const val EXPIRATION_YEAR_START = "20"
 internal const val EXPIRATION_YEAR_MIN_LENGTH = 2
 internal const val SECURITY_CODE_MIN_LENGTH = 3
-internal const val CARD_BIN_LENGTH = 6
+internal const val CARD_BIN_LENGTH = 8
 
 internal const val ERROR_SECURITY_CODE_MIN_LENGTH = "security code length cannot be smaller than tree"
 internal const val ERROR_EXPIRATION_DATE_EMPTY = "expiration date cannot be empty"

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/data/remote/utils/Constants.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/data/remote/utils/Constants.kt
@@ -7,8 +7,6 @@ internal const val PRODUCT_ID: String = BuildConfig.CORE_METHODS_PRODUCT_ID
 internal const val EXPIRATION_YEAR_START = "20"
 internal const val EXPIRATION_YEAR_MIN_LENGTH = 2
 internal const val SECURITY_CODE_MIN_LENGTH = 3
-internal const val CARD_BIN_LENGTH = 8
-
 internal const val ERROR_SECURITY_CODE_MIN_LENGTH = "security code length cannot be smaller than tree"
 internal const val ERROR_EXPIRATION_DATE_EMPTY = "expiration date cannot be empty"
 internal const val ERROR_EXPIRATION_DATE_LENGTH = "expiration date length cannot be smaller than two"

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardIdTokenUseCase.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardIdTokenUseCase.kt
@@ -6,7 +6,6 @@ import com.mercadopago.sdk.android.coremethods.data.remote.utils.ERROR_EXPIRATIO
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.ERROR_SECURITY_CODE_MIN_LENGTH
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.EXPIRATION_YEAR_MIN_LENGTH
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.EXPIRATION_YEAR_START
-import com.mercadopago.sdk.android.coremethods.data.remote.utils.SECURITY_CODE_MIN_LENGTH
 import com.mercadopago.sdk.android.coremethods.di.SecurityCodeLengthProvider
 import com.mercadopago.sdk.android.coremethods.domain.model.BuyerIdentification
 import com.mercadopago.sdk.android.coremethods.domain.model.CardToken
@@ -17,6 +16,7 @@ import com.mercadopago.sdk.android.coremethods.domain.repository.CoreMethodsRepo
 import com.mercadopago.sdk.android.coremethods.domain.usecase.validations.IsSecurityCodeValidUseCase
 import com.mercadopago.sdk.android.coremethods.domain.utils.Result
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.INT_TWO
+import com.mercadopago.sdk.android.coremethods.ui.components.textfield.securitycode.SECURITY_CODE_MIN_LENGTH
 import com.mercadopago.sdk.android.di.SessionIdProvider
 
 @Suppress("ReturnCount", "NoEmptyFirstLineInMethodBlock")

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardTokenPCIUseCase.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardTokenPCIUseCase.kt
@@ -2,7 +2,6 @@ package com.mercadopago.sdk.android.coremethods.domain.usecase
 
 import com.mercadolibre.android.device.sdk.DeviceSDK
 import com.mercadopago.sdk.android.coremethods.BuildConfig
-import com.mercadopago.sdk.android.coremethods.data.remote.utils.CARD_BIN_LENGTH
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.ERROR_EXPIRATION_DATE_EMPTY
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.ERROR_EXPIRATION_DATE_LENGTH
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.ERROR_SECURITY_CODE_MIN_LENGTH
@@ -18,6 +17,7 @@ import com.mercadopago.sdk.android.coremethods.domain.repository.CoreMethodsRepo
 import com.mercadopago.sdk.android.coremethods.domain.usecase.validations.IsSecurityCodeValidUseCase
 import com.mercadopago.sdk.android.coremethods.domain.utils.Result
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.INT_TWO
+import com.mercadopago.sdk.android.coremethods.ui.components.textfield.cardnumber.BIN_LENGTH
 import com.mercadopago.sdk.android.di.SessionIdProvider
 
 @Suppress("ReturnCount", "NoEmptyFirstLineInMethodBlock")
@@ -42,7 +42,7 @@ internal class GenerateCardTokenPCIUseCase(
         }
 
         val securityCodeLength: Int =
-            when (val result = paymentMethodsUseCase(cardNumber.take(CARD_BIN_LENGTH))) {
+            when (val result = paymentMethodsUseCase(cardNumber.take(BIN_LENGTH))) {
                 is Result.Success -> result.data.firstOrNull()?.card?.securityCode?.length
                     ?: SECURITY_CODE_MIN_LENGTH
 

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardTokenPCIUseCase.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardTokenPCIUseCase.kt
@@ -7,7 +7,6 @@ import com.mercadopago.sdk.android.coremethods.data.remote.utils.ERROR_EXPIRATIO
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.ERROR_SECURITY_CODE_MIN_LENGTH
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.EXPIRATION_YEAR_MIN_LENGTH
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.EXPIRATION_YEAR_START
-import com.mercadopago.sdk.android.coremethods.data.remote.utils.SECURITY_CODE_MIN_LENGTH
 import com.mercadopago.sdk.android.coremethods.domain.model.BuyerIdentification
 import com.mercadopago.sdk.android.coremethods.domain.model.CardToken
 import com.mercadopago.sdk.android.coremethods.domain.model.ResultError
@@ -17,7 +16,8 @@ import com.mercadopago.sdk.android.coremethods.domain.repository.CoreMethodsRepo
 import com.mercadopago.sdk.android.coremethods.domain.usecase.validations.IsSecurityCodeValidUseCase
 import com.mercadopago.sdk.android.coremethods.domain.utils.Result
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.INT_TWO
-import com.mercadopago.sdk.android.coremethods.ui.components.textfield.cardnumber.BIN_LENGTH
+import com.mercadopago.sdk.android.coremethods.ui.components.textfield.cardnumber.CARD_BIN_LENGTH
+import com.mercadopago.sdk.android.coremethods.ui.components.textfield.securitycode.SECURITY_CODE_MIN_LENGTH
 import com.mercadopago.sdk.android.di.SessionIdProvider
 
 @Suppress("ReturnCount", "NoEmptyFirstLineInMethodBlock")
@@ -42,7 +42,7 @@ internal class GenerateCardTokenPCIUseCase(
         }
 
         val securityCodeLength: Int =
-            when (val result = paymentMethodsUseCase(cardNumber.take(BIN_LENGTH))) {
+            when (val result = paymentMethodsUseCase(cardNumber.take(CARD_BIN_LENGTH))) {
                 is Result.Success -> result.data.firstOrNull()?.card?.securityCode?.length
                     ?: SECURITY_CODE_MIN_LENGTH
 

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardTokenUseCase.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardTokenUseCase.kt
@@ -2,7 +2,6 @@ package com.mercadopago.sdk.android.coremethods.domain.usecase
 
 import com.mercadolibre.android.device.sdk.DeviceSDK
 import com.mercadopago.sdk.android.coremethods.BuildConfig
-import com.mercadopago.sdk.android.coremethods.data.remote.utils.CARD_BIN_LENGTH
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.ERROR_EXPIRATION_DATE_EMPTY
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.ERROR_EXPIRATION_DATE_LENGTH
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.ERROR_SECURITY_CODE_MIN_LENGTH
@@ -18,6 +17,7 @@ import com.mercadopago.sdk.android.coremethods.domain.repository.CoreMethodsRepo
 import com.mercadopago.sdk.android.coremethods.domain.usecase.validations.IsSecurityCodeValidUseCase
 import com.mercadopago.sdk.android.coremethods.domain.utils.Result
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.INT_TWO
+import com.mercadopago.sdk.android.coremethods.ui.components.textfield.cardnumber.BIN_LENGTH
 import com.mercadopago.sdk.android.di.SessionIdProvider
 
 @Suppress("ReturnCount", "NoEmptyFirstLineInMethodBlock")
@@ -43,7 +43,7 @@ internal class GenerateCardTokenUseCase(
             }
 
             val securityCodeLength: Int =
-                when (val result = paymentMethodsUseCase(cardNumber.take(CARD_BIN_LENGTH))) {
+                when (val result = paymentMethodsUseCase(cardNumber.take(BIN_LENGTH))) {
                     is Result.Success -> result.data.firstOrNull()?.card?.securityCode?.length
                         ?: SECURITY_CODE_MIN_LENGTH
 

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardTokenUseCase.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardTokenUseCase.kt
@@ -7,7 +7,6 @@ import com.mercadopago.sdk.android.coremethods.data.remote.utils.ERROR_EXPIRATIO
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.ERROR_SECURITY_CODE_MIN_LENGTH
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.EXPIRATION_YEAR_MIN_LENGTH
 import com.mercadopago.sdk.android.coremethods.data.remote.utils.EXPIRATION_YEAR_START
-import com.mercadopago.sdk.android.coremethods.data.remote.utils.SECURITY_CODE_MIN_LENGTH
 import com.mercadopago.sdk.android.coremethods.domain.model.BuyerIdentification
 import com.mercadopago.sdk.android.coremethods.domain.model.CardToken
 import com.mercadopago.sdk.android.coremethods.domain.model.ResultError
@@ -17,7 +16,8 @@ import com.mercadopago.sdk.android.coremethods.domain.repository.CoreMethodsRepo
 import com.mercadopago.sdk.android.coremethods.domain.usecase.validations.IsSecurityCodeValidUseCase
 import com.mercadopago.sdk.android.coremethods.domain.utils.Result
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.INT_TWO
-import com.mercadopago.sdk.android.coremethods.ui.components.textfield.cardnumber.BIN_LENGTH
+import com.mercadopago.sdk.android.coremethods.ui.components.textfield.cardnumber.CARD_BIN_LENGTH
+import com.mercadopago.sdk.android.coremethods.ui.components.textfield.securitycode.SECURITY_CODE_MIN_LENGTH
 import com.mercadopago.sdk.android.di.SessionIdProvider
 
 @Suppress("ReturnCount", "NoEmptyFirstLineInMethodBlock")
@@ -43,7 +43,7 @@ internal class GenerateCardTokenUseCase(
             }
 
             val securityCodeLength: Int =
-                when (val result = paymentMethodsUseCase(cardNumber.take(BIN_LENGTH))) {
+                when (val result = paymentMethodsUseCase(cardNumber.take(CARD_BIN_LENGTH))) {
                     is Result.Success -> result.data.firstOrNull()?.card?.securityCode?.length
                         ?: SECURITY_CODE_MIN_LENGTH
 

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GetPaymentMethodsUseCase.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GetPaymentMethodsUseCase.kt
@@ -12,17 +12,10 @@ internal class GetPaymentMethodsUseCase(
     suspend operator fun invoke(
         bin: String,
     ): Result<List<PaymentMethod>, ResultError> {
-        if (bin.length < MIN_BIN_LENGTH) {
-            return Result.Error(ResultError.Validation(message = "BIN must have at least 6 digits"))
-        }
         return repository.getPaymentMethods(
             GetPaymentMethodsParams(
                 bin = bin.toIntOrNull(),
             ),
         )
-    }
-
-    companion object {
-        const val MIN_BIN_LENGTH = 6
     }
 }

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GetPaymentMethodsUseCase.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GetPaymentMethodsUseCase.kt
@@ -12,10 +12,17 @@ internal class GetPaymentMethodsUseCase(
     suspend operator fun invoke(
         bin: String,
     ): Result<List<PaymentMethod>, ResultError> {
+        if (bin.length < MIN_BIN_LENGTH) {
+            return Result.Error(ResultError.Validation(message = "BIN must have at least 6 digits"))
+        }
         return repository.getPaymentMethods(
             GetPaymentMethodsParams(
                 bin = bin.toIntOrNull(),
             ),
         )
+    }
+
+    companion object {
+        const val MIN_BIN_LENGTH = 6
     }
 }

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/cardnumber/CardNumberTextField.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/cardnumber/CardNumberTextField.kt
@@ -27,7 +27,7 @@ import com.mercadopago.sdk.android.coremethods.ui.components.textfield.pcitextfi
 import com.mercadopago.sdk.android.coremethods.ui.utils.MaskVisualTransformationDefaults
 
 internal const val COMPONENT_NAME_CARD_NUMBER = "cardNumber"
-internal const val BIN_LENGTH = 8
+internal const val CARD_BIN_LENGTH = 8
 internal const val DEFAULT_CARD_NUMBER_MAX_LENGTH = 19
 internal const val LAST_DIGITS_LENGTH = 4
 internal const val MIN_CARD_LENGTH = 8L
@@ -95,10 +95,10 @@ fun CardNumberTextField(
         onValueChange = { value ->
             val inputDigits = value.filter { it.isDigit() }.take(maxLength)
             onEvent(CardNumberTextFieldEvent.OnLengthChanged(length = inputDigits.length))
-            if (inputDigits.length >= BIN_LENGTH && state.input.length < BIN_LENGTH) {
-                onEvent(CardNumberTextFieldEvent.OnBinChanged(cardBin = inputDigits.take(BIN_LENGTH)))
+            if (inputDigits.length >= CARD_BIN_LENGTH && state.input.length < CARD_BIN_LENGTH) {
+                onEvent(CardNumberTextFieldEvent.OnBinChanged(cardBin = inputDigits.take(CARD_BIN_LENGTH)))
             }
-            if (inputDigits.length < BIN_LENGTH && state.input.length >= BIN_LENGTH) {
+            if (inputDigits.length < CARD_BIN_LENGTH && state.input.length >= CARD_BIN_LENGTH) {
                 onEvent(CardNumberTextFieldEvent.OnBinChanged(cardBin = null))
             }
             val isValid = isCardNumberValidUseCase(inputDigits)

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/securitycode/SecurityCodeField.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/securitycode/SecurityCodeField.kt
@@ -27,7 +27,7 @@ import com.mercadopago.sdk.android.coremethods.ui.components.textfield.pcitextfi
 import com.mercadopago.sdk.android.initializer.MercadoPagoSDK
 
 internal const val COMPONENT_NAME_SECURITY_CODE = "securityCode"
-internal const val MIN_LENGTH = 3
+internal const val SECURITY_CODE_MIN_LENGTH = 3
 
 /**
  * A PCI-compliant security code input component for entering card CVV/CVC codes.
@@ -92,7 +92,7 @@ fun SecurityCodeTextField(
     modifier: Modifier = Modifier,
     state: PCIFieldState,
     onEvent: (SecurityCodeTextFieldEvent) -> Unit,
-    securityCodeSize: Int = MIN_LENGTH,
+    securityCodeSize: Int = SECURITY_CODE_MIN_LENGTH,
     enabled: Boolean = true,
     readOnly: Boolean = false,
     decorationBox: @Composable (
@@ -164,7 +164,7 @@ internal fun SecurityCodeEmptyPreview() {
         state = state,
         onEvent = { securityCodeFieldEvent ->
         },
-        securityCodeSize = MIN_LENGTH,
+        securityCodeSize = SECURITY_CODE_MIN_LENGTH,
     )
 }
 
@@ -182,6 +182,6 @@ internal fun SecurityCodeFilledPreview() {
         state = state,
         onEvent = { securityCodeFieldEvent ->
         },
-        securityCodeSize = MIN_LENGTH,
+        securityCodeSize = SECURITY_CODE_MIN_LENGTH,
     )
 }

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/securitycode/xml/SecurityCodeTextField.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/securitycode/xml/SecurityCodeTextField.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import com.mercadopago.sdk.android.coremethods.R
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.pcitextfield.PCIFieldState
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.pcitextfield.rememberPCIFieldState
-import com.mercadopago.sdk.android.coremethods.ui.components.textfield.securitycode.MIN_LENGTH
+import com.mercadopago.sdk.android.coremethods.ui.components.textfield.securitycode.SECURITY_CODE_MIN_LENGTH
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.securitycode.SecurityCodeTextField
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.securitycode.SecurityCodeTextFieldEvent
 
@@ -88,7 +88,7 @@ class SecurityCodeTextField @JvmOverloads constructor(
      * This value determines the length of the security code input
      * (typically 3 for most cards, 4 for American Express).
      */
-    var securityCodeSize: Int = MIN_LENGTH
+    var securityCodeSize: Int = SECURITY_CODE_MIN_LENGTH
 
     /**
      * Whether the field is read-only.
@@ -131,7 +131,7 @@ class SecurityCodeTextField @JvmOverloads constructor(
             try {
                 securityCodeSize = getInteger(
                     R.styleable.MPSecurityFieldTextFieldXML_securityCodeSize,
-                    MIN_LENGTH,
+                    SECURITY_CODE_MIN_LENGTH,
                 )
 
                 readOnly = getBoolean(R.styleable.MPSecurityFieldTextFieldXML_readOnly, false)

--- a/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardTokenPCIUseCaseTest.kt
+++ b/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardTokenPCIUseCaseTest.kt
@@ -294,13 +294,13 @@ internal class GenerateCardTokenPCIUseCaseTest {
                 card = CardModel(securityCode = SecurityCodeModel(length = 3)),
             )
             every { isSecurityCodeValidUseCase(any<Int>(), any<Int>()) } returns true
-            coEvery { paymentMethodsUseCase("411111") } returns Result.Success(listOf(mockPaymentMethod))
+            coEvery { paymentMethodsUseCase("41111111") } returns Result.Success(listOf(mockPaymentMethod))
             coEvery { repository.generateCardToken(any()) } returns Result.Success(expectedCardToken)
             useCase(
                 cardNumber = inputCardNumber,
                 securityCode = inputSecurityCode,
                 expirationDate = inputExpirationDate,
             )
-            coVerify { paymentMethodsUseCase("411111") }
+            coVerify { paymentMethodsUseCase("41111111") }
         }
 }

--- a/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardTokenPCIUseCaseTest.kt
+++ b/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GenerateCardTokenPCIUseCaseTest.kt
@@ -294,13 +294,13 @@ internal class GenerateCardTokenPCIUseCaseTest {
                 card = CardModel(securityCode = SecurityCodeModel(length = 3)),
             )
             every { isSecurityCodeValidUseCase(any<Int>(), any<Int>()) } returns true
-            coEvery { paymentMethodsUseCase("411") } returns Result.Success(listOf(mockPaymentMethod))
+            coEvery { paymentMethodsUseCase("411111") } returns Result.Success(listOf(mockPaymentMethod))
             coEvery { repository.generateCardToken(any()) } returns Result.Success(expectedCardToken)
             useCase(
                 cardNumber = inputCardNumber,
                 securityCode = inputSecurityCode,
                 expirationDate = inputExpirationDate,
             )
-            coVerify { paymentMethodsUseCase("411") }
+            coVerify { paymentMethodsUseCase("411111") }
         }
 }

--- a/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GetPaymentMethodUseCaseTest.kt
+++ b/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GetPaymentMethodUseCaseTest.kt
@@ -41,43 +41,4 @@ class GetPaymentMethodUseCaseTest {
 
             assertEquals(expectedErrorResult, result)
         }
-
-    @Test
-    fun `getPaymentMethods should return validation error when bin has less than 6 digits`() =
-        runBlocking {
-            val bin = "12345"
-
-            val result = useCase(bin)
-
-            assertEquals(
-                Result.Error(ResultError.Validation(message = "BIN must have at least 6 digits")),
-                result,
-            )
-        }
-
-    @Test
-    fun `getPaymentMethods should call repository when bin has exactly 6 digits`() =
-        runBlocking {
-            val bin = "123456"
-
-            val expectedResult = Result.Success(listOf(PaymentMethod()))
-            coEvery { repository.getPaymentMethods(any()) } returns expectedResult
-
-            val result = useCase(bin)
-
-            assertEquals(expectedResult, result)
-        }
-
-    @Test
-    fun `getPaymentMethods should call repository when bin has more than 6 digits`() =
-        runBlocking {
-            val bin = "12345678"
-
-            val expectedResult = Result.Success(listOf(PaymentMethod()))
-            coEvery { repository.getPaymentMethods(any()) } returns expectedResult
-
-            val result = useCase(bin)
-
-            assertEquals(expectedResult, result)
-        }
 }

--- a/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GetPaymentMethodUseCaseTest.kt
+++ b/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/domain/usecase/GetPaymentMethodUseCaseTest.kt
@@ -17,7 +17,7 @@ class GetPaymentMethodUseCaseTest {
     @Test
     fun `getPaymentMethods should call repository with correct parameters`() =
         runBlocking {
-            val bin = "12345"
+            val bin = "123456"
 
             val expectedResult = Result.Success(listOf(PaymentMethod()))
             coEvery { repository.getPaymentMethods(any()) } returns expectedResult
@@ -30,7 +30,7 @@ class GetPaymentMethodUseCaseTest {
     @Test
     fun `getPaymentMethods should return error when repository fails`() =
         runBlocking {
-            val bin = "12345"
+            val bin = "123456"
 
             val expectedErrorResult = Result.Error(
                 ResultError.Request(code = "400", message = "Repository error"),
@@ -40,5 +40,44 @@ class GetPaymentMethodUseCaseTest {
             val result = useCase(bin)
 
             assertEquals(expectedErrorResult, result)
+        }
+
+    @Test
+    fun `getPaymentMethods should return validation error when bin has less than 6 digits`() =
+        runBlocking {
+            val bin = "12345"
+
+            val result = useCase(bin)
+
+            assertEquals(
+                Result.Error(ResultError.Validation(message = "BIN must have at least 6 digits")),
+                result,
+            )
+        }
+
+    @Test
+    fun `getPaymentMethods should call repository when bin has exactly 6 digits`() =
+        runBlocking {
+            val bin = "123456"
+
+            val expectedResult = Result.Success(listOf(PaymentMethod()))
+            coEvery { repository.getPaymentMethods(any()) } returns expectedResult
+
+            val result = useCase(bin)
+
+            assertEquals(expectedResult, result)
+        }
+
+    @Test
+    fun `getPaymentMethods should call repository when bin has more than 6 digits`() =
+        runBlocking {
+            val bin = "12345678"
+
+            val expectedResult = Result.Success(listOf(PaymentMethod()))
+            coEvery { repository.getPaymentMethods(any()) } returns expectedResult
+
+            val result = useCase(bin)
+
+            assertEquals(expectedResult, result)
         }
 }

--- a/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/cardnumber/CardNumberTextFieldTest.kt
+++ b/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/ui/components/textfield/cardnumber/CardNumberTextFieldTest.kt
@@ -76,7 +76,7 @@ internal class CardNumberTextFieldTest {
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = false), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = true), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnLengthChanged(length = 15), awaitItem())
-                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(BIN_LENGTH)), awaitItem())
+                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(CARD_BIN_LENGTH)), awaitItem())
                 assertEquals(
                     CardNumberTextFieldEvent.OnLastFourDigitsFilled(
                         lastFourDigits = input.takeLast(LAST_DIGITS_LENGTH),
@@ -111,7 +111,7 @@ internal class CardNumberTextFieldTest {
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = false), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = true), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnLengthChanged(length = 15), awaitItem())
-                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(BIN_LENGTH)), awaitItem())
+                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(CARD_BIN_LENGTH)), awaitItem())
                 assertEquals(
                     CardNumberTextFieldEvent.OnLastFourDigitsFilled(
                         lastFourDigits = input.takeLast(LAST_DIGITS_LENGTH),
@@ -143,7 +143,7 @@ internal class CardNumberTextFieldTest {
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = false), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = true), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnLengthChanged(length = 16), awaitItem())
-                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(BIN_LENGTH)), awaitItem())
+                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(CARD_BIN_LENGTH)), awaitItem())
                 assertEquals(
                     CardNumberTextFieldEvent.OnLastFourDigitsFilled(
                         lastFourDigits = input.takeLast(LAST_DIGITS_LENGTH),
@@ -175,7 +175,7 @@ internal class CardNumberTextFieldTest {
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = false), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = true), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnLengthChanged(length = 19), awaitItem())
-                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(BIN_LENGTH)), awaitItem())
+                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(CARD_BIN_LENGTH)), awaitItem())
                 assertEquals(
                     CardNumberTextFieldEvent.OnLastFourDigitsFilled(
                         lastFourDigits = input.takeLast(LAST_DIGITS_LENGTH),
@@ -207,7 +207,7 @@ internal class CardNumberTextFieldTest {
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = false), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = true), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnLengthChanged(length = 14), awaitItem())
-                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(BIN_LENGTH)), awaitItem())
+                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(CARD_BIN_LENGTH)), awaitItem())
                 assertEquals(
                     CardNumberTextFieldEvent.OnLastFourDigitsFilled(
                         lastFourDigits = input.takeLast(LAST_DIGITS_LENGTH),
@@ -245,7 +245,7 @@ internal class CardNumberTextFieldTest {
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = false), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = true), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnLengthChanged(length = maxLength), awaitItem())
-                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(BIN_LENGTH)), awaitItem())
+                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(CARD_BIN_LENGTH)), awaitItem())
                 assertEquals(
                     CardNumberTextFieldEvent.OnLastFourDigitsFilled(
                         lastFourDigits = inputWithMaxLength.takeLast(LAST_DIGITS_LENGTH),
@@ -276,7 +276,7 @@ internal class CardNumberTextFieldTest {
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = false), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnFocusChanged(isFocused = true), awaitItem())
                 assertEquals(CardNumberTextFieldEvent.OnLengthChanged(length = 14), awaitItem())
-                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(BIN_LENGTH)), awaitItem())
+                assertEquals(CardNumberTextFieldEvent.OnBinChanged(cardBin = input.take(CARD_BIN_LENGTH)), awaitItem())
                 assertEquals(
                     CardNumberTextFieldEvent.OnLastFourDigitsFilled(
                         lastFourDigits = input.takeLast(LAST_DIGITS_LENGTH),


### PR DESCRIPTION
# Pull Request
3824](Hotfix): Changed card_bin_length to 6
## Ticket or Issue link
3824

## Description
Its necessary to aways add a security code when generate a card token. but when the security code length is 0, then is optional.
- For this. whee made a call to payment methods to get the security code length in all tokenizations calls.

**The problem is:** We are taking just the first 3 digits, and have to be 6 or 8.

This PR adjust this behavior

## Checklist
- [ ] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [ ] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<!---
Provide videos or screenshots. You can change their size in the src
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>
-->

https://github.com/user-attachments/assets/c15cf625-2e6b-4261-ad8a-debdb6680a7b


https://github.com/user-attachments/assets/d4bcccfd-4df7-4da7-af9d-1b1ec61fc169


