### PR TITLE
[3816](Fix): Expiration date validation message

### DIFF
--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/state/CardPaymentScreenState.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/state/CardPaymentScreenState.kt
@@ -52,7 +52,6 @@ internal data class ExpirationDateState(
     override val isValid: Boolean = false,
     override val showPlaceHolder: Boolean = true,
     val length: Int = 0,
-    val isDateValid: Boolean = true,
 ) : FieldState
 
 internal data class CardNumberState(

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/state/CardPaymentScreenState.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/state/CardPaymentScreenState.kt
@@ -52,6 +52,7 @@ internal data class ExpirationDateState(
     override val isValid: Boolean = false,
     override val showPlaceHolder: Boolean = true,
     val length: Int = 0,
+    val isDateValid: Boolean = true,
 ) : FieldState
 
 internal data class CardNumberState(

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/validation/ExpirationDateVerifier.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/validation/ExpirationDateVerifier.kt
@@ -13,6 +13,7 @@ internal class ExpirationDateVerifier(
         listOfNotNull(
             checkEmpty(state),
             checkIncomplete(state),
+            checkInvalid(state),
         ).firstOrNull().orEmpty()
 
     private fun checkEmpty(
@@ -30,6 +31,16 @@ internal class ExpirationDateVerifier(
     ): String? {
         return if (state.length > 0 && !state.filled) {
             stringProvider.getString(R.string.card_form_error_expiration_incomplete)
+        } else {
+            null
+        }
+    }
+
+    private fun checkInvalid(
+        state: ExpirationDateState,
+    ): String? {
+        return if (state.filled && !state.isDateValid) {
+            stringProvider.getString(R.string.card_form_error_expiration_invalid)
         } else {
             null
         }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/validation/ExpirationDateVerifier.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/validation/ExpirationDateVerifier.kt
@@ -39,7 +39,7 @@ internal class ExpirationDateVerifier(
     private fun checkInvalid(
         state: ExpirationDateState,
     ): String? {
-        return if (state.filled && !state.isDateValid) {
+        return if (state.filled && !state.isValid) {
             stringProvider.getString(R.string.card_form_error_expiration_invalid)
         } else {
             null

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModel.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModel.kt
@@ -51,6 +51,7 @@ import kotlinx.coroutines.launch
 @Suppress(
     "TooManyFunctions",
     "LongParameterList",
+    "LargeClass",
 )
 internal class CardPaymentViewModel(
     private val stateFactory: CardPaymentScreenStateFactory,
@@ -173,6 +174,15 @@ internal class CardPaymentViewModel(
                 if (event.length.isBeingCleared(previousLength)) {
                     handleExpirationDateInputError(shouldUpdateError = false)
                 }
+            }
+
+            is ExpirationDateTextFieldEvent.IsValid -> {
+                _viewState.value = _viewState.value.copy(
+                    expirationDateState = _viewState.value.expirationDateState.copy(
+                        isDateValid = event.isValid,
+                    ),
+                )
+                handleExpirationDateInputError()
             }
         }
     }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModel.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModel.kt
@@ -179,10 +179,9 @@ internal class CardPaymentViewModel(
             is ExpirationDateTextFieldEvent.IsValid -> {
                 _viewState.value = _viewState.value.copy(
                     expirationDateState = _viewState.value.expirationDateState.copy(
-                        isDateValid = event.isValid,
+                        isValid = event.isValid,
                     ),
                 )
-                handleExpirationDateInputError()
             }
         }
     }

--- a/checkout/src/main/res/values-es-rAR/strings.xml
+++ b/checkout/src/main/res/values-es-rAR/strings.xml
@@ -27,6 +27,7 @@
     <string name="card_form_error_card_number_incomplete">Ingresá el número completo</string>
     <string name="card_form_error_document_all_zeros">Ingresalo como figura en el documento.</string>
     <string name="card_form_error_expiration_incomplete">Ingresá la fecha completa</string>
+    <string name="card_form_error_expiration_invalid">Ingresá una fecha válida.</string>
     <string name="card_form_error_cvv_incomplete">Ingresá el código completo</string>
     <string name="card_form_error_insufficient_amount">Verificá que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>

--- a/checkout/src/main/res/values-es-rCL/strings.xml
+++ b/checkout/src/main/res/values-es-rCL/strings.xml
@@ -27,6 +27,7 @@
     <string name="card_form_error_card_number_incomplete">Ingresa el número completo</string>
     <string name="card_form_error_document_all_zeros">Ingrésalo como aparece en el documento.</string>
     <string name="card_form_error_expiration_incomplete">Ingresa la fecha completa</string>
+    <string name="card_form_error_expiration_invalid">Ingresa una fecha válida.</string>
     <string name="card_form_error_cvv_incomplete">Ingresa el código completo</string>
     <string name="card_form_error_insufficient_amount">Verifica que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>

--- a/checkout/src/main/res/values-es-rCO/strings.xml
+++ b/checkout/src/main/res/values-es-rCO/strings.xml
@@ -27,6 +27,7 @@
     <string name="card_form_error_card_number_incomplete">Ingresa el número completo</string>
     <string name="card_form_error_document_all_zeros">Ingrésalo como aparece en el documento.</string>
     <string name="card_form_error_expiration_incomplete">Ingresa la fecha completa</string>
+    <string name="card_form_error_expiration_invalid">Ingresa una fecha válida.</string>
     <string name="card_form_error_cvv_incomplete">Ingresa el código completo</string>
     <string name="card_form_error_insufficient_amount">Verifica que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>

--- a/checkout/src/main/res/values-es-rMX/strings.xml
+++ b/checkout/src/main/res/values-es-rMX/strings.xml
@@ -27,6 +27,7 @@
     <string name="card_form_error_card_number_incomplete">Ingresa el número completo</string>
     <string name="card_form_error_document_all_zeros">Ingrésalo como aparece en el documento.</string>
     <string name="card_form_error_expiration_incomplete">Ingresa la fecha completa</string>
+    <string name="card_form_error_expiration_invalid">Ingresa una fecha válida.</string>
     <string name="card_form_error_cvv_incomplete">Ingresa el código completo</string>
     <string name="card_form_error_insufficient_amount">Verifica que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>

--- a/checkout/src/main/res/values-es-rPE/strings.xml
+++ b/checkout/src/main/res/values-es-rPE/strings.xml
@@ -27,6 +27,7 @@
     <string name="card_form_error_card_number_incomplete">Ingresa el número completo</string>
     <string name="card_form_error_document_all_zeros">Ingrésalo como aparece en el documento.</string>
     <string name="card_form_error_expiration_incomplete">Ingresa la fecha completa</string>
+    <string name="card_form_error_expiration_invalid">Ingresa una fecha válida.</string>
     <string name="card_form_error_cvv_incomplete">Ingresa el código completo</string>
     <string name="card_form_error_insufficient_amount">Verifica que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>

--- a/checkout/src/main/res/values-es-rUY/strings.xml
+++ b/checkout/src/main/res/values-es-rUY/strings.xml
@@ -27,6 +27,7 @@
     <string name="card_form_error_card_number_incomplete">Ingresá el número completo</string>
     <string name="card_form_error_document_all_zeros">Ingresalo como figura en el documento.</string>
     <string name="card_form_error_expiration_incomplete">Ingresá la fecha completa</string>
+    <string name="card_form_error_expiration_invalid">Ingresá una fecha válida.</string>
     <string name="card_form_error_cvv_incomplete">Ingresá el código completo</string>
     <string name="card_form_error_insufficient_amount">Verificá que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>

--- a/checkout/src/main/res/values-pt-rBR/strings.xml
+++ b/checkout/src/main/res/values-pt-rBR/strings.xml
@@ -27,6 +27,7 @@
     <string name="card_form_error_card_number_incomplete">Insira o número completo</string>
     <string name="card_form_error_document_all_zeros">Insira-o conforme está no documento.</string>
     <string name="card_form_error_expiration_incomplete">Insira a data completa</string>
+    <string name="card_form_error_expiration_invalid">Insira uma data válida.</string>
     <string name="card_form_error_cvv_incomplete">Insira o código completo</string>
     <string name="card_form_error_insufficient_amount">Verifique se o cartão tem limite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">A loja não aceita cartões</string>

--- a/checkout/src/main/res/values/strings.xml
+++ b/checkout/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="card_form_error_card_number_incomplete">Ingresá el número completo</string>
     <string name="card_form_error_document_all_zeros">Ingresalo como figura en el documento.</string>
     <string name="card_form_error_expiration_incomplete">Ingresá la fecha completa</string>
+    <string name="card_form_error_expiration_invalid">Ingresá una fecha válida.</string>
     <string name="card_form_error_cvv_incomplete">Ingresá el código completo</string>
     <string name="card_form_error_insufficient_amount">Verificá que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/validation/ExpirationDateVerifierTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/validation/ExpirationDateVerifierTest.kt
@@ -34,18 +34,18 @@ internal class ExpirationDateVerifierTest {
     }
 
     @Test
-    fun `when filled and isDateValid is false then returns invalid date error`() {
+    fun `when filled and isValid is false then returns invalid date error`() {
         every { stringProvider.getString(R.string.card_form_error_expiration_invalid) } returns "invalid date"
 
-        val state = ExpirationDateState(length = 4, filled = true, isDateValid = false)
+        val state = ExpirationDateState(length = 4, filled = true, isValid = false)
         val result = verifier.verify(state)
 
         assertEquals("invalid date", result)
     }
 
     @Test
-    fun `when filled and isDateValid is true then returns empty string`() {
-        val state = ExpirationDateState(length = 4, filled = true, isDateValid = true)
+    fun `when filled and isValid is true then returns empty string`() {
+        val state = ExpirationDateState(length = 4, filled = true, isValid = true)
         val result = verifier.verify(state)
 
         assertTrue(result.isEmpty())

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/validation/ExpirationDateVerifierTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/validation/ExpirationDateVerifierTest.kt
@@ -1,0 +1,53 @@
+package com.mercadopago.sdk.android.checkout.presentation.validation
+
+import com.mercadopago.android.sdk.checkout.R
+import com.mercadopago.sdk.android.checkout.domain.provider.StringProvider
+import com.mercadopago.sdk.android.checkout.presentation.state.ExpirationDateState
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class ExpirationDateVerifierTest {
+    private val stringProvider: StringProvider = mockk()
+    private val verifier = ExpirationDateVerifier(stringProvider)
+
+    @Test
+    fun `when length is 0 then returns required field error`() {
+        every { stringProvider.getString(R.string.card_form_error_required_field) } returns "required"
+
+        val state = ExpirationDateState(length = 0)
+        val result = verifier.verify(state)
+
+        assertEquals("required", result)
+    }
+
+    @Test
+    fun `when length greater than 0 and not filled then returns incomplete error`() {
+        every { stringProvider.getString(R.string.card_form_error_expiration_incomplete) } returns "incomplete"
+
+        val state = ExpirationDateState(length = 2, filled = false)
+        val result = verifier.verify(state)
+
+        assertEquals("incomplete", result)
+    }
+
+    @Test
+    fun `when filled and isDateValid is false then returns invalid date error`() {
+        every { stringProvider.getString(R.string.card_form_error_expiration_invalid) } returns "invalid date"
+
+        val state = ExpirationDateState(length = 4, filled = true, isDateValid = false)
+        val result = verifier.verify(state)
+
+        assertEquals("invalid date", result)
+    }
+
+    @Test
+    fun `when filled and isDateValid is true then returns empty string`() {
+        val state = ExpirationDateState(length = 4, filled = true, isDateValid = true)
+        val result = verifier.verify(state)
+
+        assertTrue(result.isEmpty())
+    }
+}


### PR DESCRIPTION
# Pull Request
Expiration date, date validation
## Ticket or Issue link
3816

## Description
  The expiration date field already had an IsValid event emitted by the component when the entered date is invalid (past date or invalid month), but this event was not being      
  handled — so no error was shown to the user.                                                                                                                                     
                                                                                                                                                                                   
  Changes:        
  - Handle ExpirationDateTextFieldEvent.IsValid in CardPaymentViewModel, updating isDateValid on the state and triggering field validation
  - Added isDateValid: Boolean = true field to ExpirationDateState to track content validity independently from the form validation result                                         
  - Added checkInvalid to ExpirationDateVerifier — triggers when filled && !isDateValid, returning the new error string                   
  - Added card_form_error_expiration_invalid string to all 8 locale files (MLB, MLA, MLM, MLC, MCO, MPE, MLU + default)   

## Checklist
- [ ] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [ ] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
![expiration_date_error](https://github.com/user-attachments/assets/358cf9c1-435c-4f26-9602-f047ec48c616)
