### PR TITLE
[3838](Fix): adjust error text to singular

### DIFF
--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/extensions/StringExtensions.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/extensions/StringExtensions.kt
@@ -21,8 +21,6 @@ internal fun String.isBeingCleared(
     previousValue: String,
 ): Boolean = this.length < previousValue.length
 
-internal fun String.removeUnderscore(): String = this.replace("_", " ")
-
 internal fun String.toCardTypeErrorMessage(
     stringProvider: StringProvider,
 ): String {
@@ -31,10 +29,9 @@ internal fun String.toCardTypeErrorMessage(
         CardType.CREDIT.value -> R.string.card_type_credit_card
         CardType.DEBIT.value -> R.string.card_type_debit_card
         CardType.PREPAID.value -> R.string.card_type_prepaid
-        else -> null
+        else -> return baseMessage
     }
-    val translatedType = cardTypeStringId?.let { stringProvider.getString(it) } ?: this.removeUnderscore()
-    return "$baseMessage $translatedType"
+    return "$baseMessage ${stringProvider.getString(cardTypeStringId)}"
 }
 
 internal fun CardBrand.toCardBrandErrorMessage(

--- a/checkout/src/main/res/values-es-rAR/strings.xml
+++ b/checkout/src/main/res/values-es-rAR/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">de crédito</string>
-    <string name="card_type_debit_card">de débito</string>
-    <string name="card_type_prepaid">prepago</string>
+    <string name="card_type_credit_card">Tarjeta de crédito</string>
+    <string name="card_type_debit_card">Tarjeta de débito</string>
+    <string name="card_type_prepaid">Tarjeta prepago</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completá este campo</string>
@@ -30,7 +30,7 @@
     <string name="card_form_error_cvv_incomplete">Ingresá el código completo</string>
     <string name="card_form_error_insufficient_amount">Verificá que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>
-    <string name="card_form_error_card_type_not_accepted">La tienda no acepta tarjetas</string>
+    <string name="card_form_error_card_type_not_accepted">La tienda no acepta</string>
 
     <!-- Security Code Tooltip Messages -->
     <string name="card_form_security_code_tooltip_back">Es un número de %d dígitos que está en el reverso de tu tarjeta.</string>

--- a/checkout/src/main/res/values-es-rAR/strings.xml
+++ b/checkout/src/main/res/values-es-rAR/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">Tarjeta de crédito</string>
-    <string name="card_type_debit_card">Tarjeta de débito</string>
-    <string name="card_type_prepaid">Tarjeta prepago</string>
+    <string name="card_type_credit_card">tarjeta de crédito.</string>
+    <string name="card_type_debit_card">tarjeta de débito.</string>
+    <string name="card_type_prepaid">tarjeta prepago.</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completá este campo</string>

--- a/checkout/src/main/res/values-es-rCL/strings.xml
+++ b/checkout/src/main/res/values-es-rCL/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">Tarjeta de crédito</string>
-    <string name="card_type_debit_card">Tarjeta de débito</string>
-    <string name="card_type_prepaid">Tarjeta prepago</string>
+    <string name="card_type_credit_card">tarjeta de crédito.</string>
+    <string name="card_type_debit_card">tarjeta de débito.</string>
+    <string name="card_type_prepaid">tarjeta prepago.</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completa este campo</string>

--- a/checkout/src/main/res/values-es-rCL/strings.xml
+++ b/checkout/src/main/res/values-es-rCL/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">de crédito</string>
-    <string name="card_type_debit_card">de débito</string>
-    <string name="card_type_prepaid">prepago</string>
+    <string name="card_type_credit_card">Tarjeta de crédito</string>
+    <string name="card_type_debit_card">Tarjeta de débito</string>
+    <string name="card_type_prepaid">Tarjeta prepago</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completa este campo</string>
@@ -30,7 +30,7 @@
     <string name="card_form_error_cvv_incomplete">Ingresa el código completo</string>
     <string name="card_form_error_insufficient_amount">Verifica que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>
-    <string name="card_form_error_card_type_not_accepted">La tienda no acepta tarjetas</string>
+    <string name="card_form_error_card_type_not_accepted">La tienda no acepta</string>
 
     <!-- Security Code Tooltip Messages -->
     <string name="card_form_security_code_tooltip_back">Es un número de %d dígitos que está en el reverso de tu tarjeta.</string>

--- a/checkout/src/main/res/values-es-rCO/strings.xml
+++ b/checkout/src/main/res/values-es-rCO/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">Tarjeta de crédito</string>
-    <string name="card_type_debit_card">Tarjeta de débito</string>
-    <string name="card_type_prepaid">Tarjeta prepago</string>
+    <string name="card_type_credit_card">tarjeta de crédito.</string>
+    <string name="card_type_debit_card">tarjeta de débito.</string>
+    <string name="card_type_prepaid">tarjeta prepago.</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completa este campo</string>

--- a/checkout/src/main/res/values-es-rCO/strings.xml
+++ b/checkout/src/main/res/values-es-rCO/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">de crédito</string>
-    <string name="card_type_debit_card">de débito</string>
-    <string name="card_type_prepaid">prepago</string>
+    <string name="card_type_credit_card">Tarjeta de crédito</string>
+    <string name="card_type_debit_card">Tarjeta de débito</string>
+    <string name="card_type_prepaid">Tarjeta prepago</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completa este campo</string>
@@ -30,7 +30,7 @@
     <string name="card_form_error_cvv_incomplete">Ingresa el código completo</string>
     <string name="card_form_error_insufficient_amount">Verifica que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>
-    <string name="card_form_error_card_type_not_accepted">La tienda no acepta tarjetas</string>
+    <string name="card_form_error_card_type_not_accepted">La tienda no acepta</string>
 
     <!-- Security Code Tooltip Messages -->
     <string name="card_form_security_code_tooltip_back">Es un número de %d dígitos que está en el reverso de tu tarjeta.</string>

--- a/checkout/src/main/res/values-es-rMX/strings.xml
+++ b/checkout/src/main/res/values-es-rMX/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">Tarjeta de crédito</string>
-    <string name="card_type_debit_card">Tarjeta de débito</string>
-    <string name="card_type_prepaid">Tarjeta prepago</string>
+    <string name="card_type_credit_card">tarjeta de crédito.</string>
+    <string name="card_type_debit_card">tarjeta de débito.</string>
+    <string name="card_type_prepaid">tarjeta prepago.</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completa este campo</string>

--- a/checkout/src/main/res/values-es-rMX/strings.xml
+++ b/checkout/src/main/res/values-es-rMX/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">de crédito</string>
-    <string name="card_type_debit_card">de débito</string>
-    <string name="card_type_prepaid">prepago</string>
+    <string name="card_type_credit_card">Tarjeta de crédito</string>
+    <string name="card_type_debit_card">Tarjeta de débito</string>
+    <string name="card_type_prepaid">Tarjeta prepago</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completa este campo</string>
@@ -30,7 +30,7 @@
     <string name="card_form_error_cvv_incomplete">Ingresa el código completo</string>
     <string name="card_form_error_insufficient_amount">Verifica que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>
-    <string name="card_form_error_card_type_not_accepted">La tienda no acepta tarjetas</string>
+    <string name="card_form_error_card_type_not_accepted">La tienda no acepta</string>
 
     <!-- Security Code Tooltip Messages -->
     <string name="card_form_security_code_tooltip_back">Es un número de %d dígitos que está en el reverso de tu tarjeta.</string>

--- a/checkout/src/main/res/values-es-rPE/strings.xml
+++ b/checkout/src/main/res/values-es-rPE/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">Tarjeta de crédito</string>
-    <string name="card_type_debit_card">Tarjeta de débito</string>
-    <string name="card_type_prepaid">Tarjeta prepago</string>
+    <string name="card_type_credit_card">tarjeta de crédito.</string>
+    <string name="card_type_debit_card">tarjeta de débito.</string>
+    <string name="card_type_prepaid">tarjeta prepago.</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completa este campo</string>

--- a/checkout/src/main/res/values-es-rPE/strings.xml
+++ b/checkout/src/main/res/values-es-rPE/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">de crédito</string>
-    <string name="card_type_debit_card">de débito</string>
-    <string name="card_type_prepaid">prepago</string>
+    <string name="card_type_credit_card">Tarjeta de crédito</string>
+    <string name="card_type_debit_card">Tarjeta de débito</string>
+    <string name="card_type_prepaid">Tarjeta prepago</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completa este campo</string>
@@ -30,7 +30,7 @@
     <string name="card_form_error_cvv_incomplete">Ingresa el código completo</string>
     <string name="card_form_error_insufficient_amount">Verifica que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>
-    <string name="card_form_error_card_type_not_accepted">La tienda no acepta tarjetas</string>
+    <string name="card_form_error_card_type_not_accepted">La tienda no acepta</string>
 
     <!-- Security Code Tooltip Messages -->
     <string name="card_form_security_code_tooltip_back">Es un número de %d dígitos que está en el reverso de tu tarjeta.</string>

--- a/checkout/src/main/res/values-es-rUY/strings.xml
+++ b/checkout/src/main/res/values-es-rUY/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">de crédito</string>
-    <string name="card_type_debit_card">de débito</string>
-    <string name="card_type_prepaid">prepago</string>
+    <string name="card_type_credit_card">Tarjeta de crédito</string>
+    <string name="card_type_debit_card">Tarjeta de débito</string>
+    <string name="card_type_prepaid">Tarjeta prepago</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completá este campo</string>
@@ -30,7 +30,7 @@
     <string name="card_form_error_cvv_incomplete">Ingresá el código completo</string>
     <string name="card_form_error_insufficient_amount">Verificá que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>
-    <string name="card_form_error_card_type_not_accepted">La tienda no acepta tarjetas</string>
+    <string name="card_form_error_card_type_not_accepted">La tienda no acepta</string>
 
     <!-- Security Code Tooltip Messages -->
     <string name="card_form_security_code_tooltip_back">Es un número de %d dígitos que está en el reverso de tu tarjeta.</string>

--- a/checkout/src/main/res/values-es-rUY/strings.xml
+++ b/checkout/src/main/res/values-es-rUY/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">Tarjeta de crédito</string>
-    <string name="card_type_debit_card">Tarjeta de débito</string>
-    <string name="card_type_prepaid">Tarjeta prepago</string>
+    <string name="card_type_credit_card">tarjeta de crédito.</string>
+    <string name="card_type_debit_card">tarjeta de débito.</string>
+    <string name="card_type_prepaid">tarjeta prepago.</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completá este campo</string>

--- a/checkout/src/main/res/values-pt-rBR/strings.xml
+++ b/checkout/src/main/res/values-pt-rBR/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Salvar cartão</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">Cartão de crédito</string>
-    <string name="card_type_debit_card">Cartão de débito</string>
-    <string name="card_type_prepaid">Cartão prepago</string>
+    <string name="card_type_credit_card">cartão de crédito.</string>
+    <string name="card_type_debit_card">cartão de débito.</string>
+    <string name="card_type_prepaid">cartão prepago.</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Preencha este campo</string>

--- a/checkout/src/main/res/values-pt-rBR/strings.xml
+++ b/checkout/src/main/res/values-pt-rBR/strings.xml
@@ -15,9 +15,9 @@
     <string name="card_form_save_button">Salvar cartão</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">de crédito</string>
-    <string name="card_type_debit_card">de débito</string>
-    <string name="card_type_prepaid">prepago</string>
+    <string name="card_type_credit_card">Cartão de crédito</string>
+    <string name="card_type_debit_card">Cartão de débito</string>
+    <string name="card_type_prepaid">Cartão prepago</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Preencha este campo</string>
@@ -30,7 +30,7 @@
     <string name="card_form_error_cvv_incomplete">Insira o código completo</string>
     <string name="card_form_error_insufficient_amount">Verifique se o cartão tem limite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">A loja não aceita cartões</string>
-    <string name="card_form_error_card_type_not_accepted">A loja não aceita cartões</string>
+    <string name="card_form_error_card_type_not_accepted">A loja não aceita</string>
 
     <!-- Security Code Tooltip Messages -->
     <string name="card_form_security_code_tooltip_back">É um número de %d dígitos que está no verso do seu cartão.</string>

--- a/checkout/src/main/res/values/strings.xml
+++ b/checkout/src/main/res/values/strings.xml
@@ -20,9 +20,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">de crédito</string>
-    <string name="card_type_debit_card">de débito</string>
-    <string name="card_type_prepaid">prepago</string>
+    <string name="card_type_credit_card">Tarjeta de crédito</string>
+    <string name="card_type_debit_card">Tarjeta de débito</string>
+    <string name="card_type_prepaid">Tarjeta prepago</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completá este campo</string>
@@ -35,7 +35,7 @@
     <string name="card_form_error_cvv_incomplete">Ingresá el código completo</string>
     <string name="card_form_error_insufficient_amount">Verificá que la tarjeta tenga límite suficiente.</string>
     <string name="card_form_error_card_brand_not_accepted">La tienda no acepta tarjetas</string>
-    <string name="card_form_error_card_type_not_accepted">La tienda no acepta tarjetas</string>
+    <string name="card_form_error_card_type_not_accepted">La tienda no acepta</string>
 
     <!-- Security Code Tooltip Messages -->
     <string name="card_form_security_code_tooltip_back">Es un número de %d dígitos que está en el reverso de tu tarjeta.</string>

--- a/checkout/src/main/res/values/strings.xml
+++ b/checkout/src/main/res/values/strings.xml
@@ -20,9 +20,9 @@
     <string name="card_form_save_button">Guardar tarjeta</string>
 
     <!-- Card Type Translations -->
-    <string name="card_type_credit_card">Tarjeta de crédito</string>
-    <string name="card_type_debit_card">Tarjeta de débito</string>
-    <string name="card_type_prepaid">Tarjeta prepago</string>
+    <string name="card_type_credit_card">tarjeta de crédito.</string>
+    <string name="card_type_debit_card">tarjeta de débito.</string>
+    <string name="card_type_prepaid">tarjeta prepago.</string>
 
     <!-- Validation Error Messages -->
     <string name="card_form_error_required_field">Completá este campo</string>


### PR DESCRIPTION
# Pull Request
Adjust error text to singular
## Ticket or Issue link
3838

## Description
 - Adjusted error message card_form_error_card_type_not_accepted from plural to singular across all supported locales (es-AR, es-CL, es-CO, es-MX, es-PE, es-UY, pt-BR, values    
  default)
  - Updated card_type_credit_card, card_type_debit_card, and card_type_prepaid strings to be standalone full labels (e.g. "de crédito" → "Tarjeta de crédito") so they can be      
  concatenated directly in the error message                                                                                                                                       
  - Fixed a double-space bug in the composed error message: the base string had a trailing space that conflicted with the space already added in StringExtensions.kt:37
                                                                                                                                                                                   
  Before: "La tienda no acepta tarjetas" (plural, generic)                                                                                                                         
  After: "La tienda no acepta Tarjeta de crédito" (singular, specific to card type) 

## Checklist
- [ ] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [ ] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<!---
Provide videos or screenshots. You can change their size in the src
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>
-->
![não aceita cartão](https://github.com/user-attachments/assets/94133839-4747-41ed-ad37-d804c3c36cf1)
