### PR TITLE
[3818](Fix): Popover movement when scroll

### DIFF
--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/cardpayment/CardPaymentScreenContent.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/cardpayment/CardPaymentScreenContent.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -19,21 +18,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.boundsInRoot
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.mercadopago.sdk.android.checkout.presentation.state.CardHolderState
 import com.mercadopago.sdk.android.checkout.presentation.state.CardNumberState
@@ -67,7 +60,6 @@ import com.mercadopago.sdk.android.coremethods.ui.utils.MaskVisualTransformation
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoAndesTheme
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoTheme
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoThemes
-import kotlin.math.roundToInt
 
 @Composable
 internal fun CardPaymentScreen(
@@ -163,125 +155,110 @@ internal fun CardPaymentScreenContent(
                         onBackPressed()
                     },
                 ) {
-                    var containerBounds by remember { mutableStateOf(Rect.Zero) }
-                    var securityCodeBounds by remember { mutableStateOf(Rect.Zero) }
-                    val density = LocalDensity.current
-                    val popoverHeightPx = with(density) { 80.dp.toPx() }
-                    Box(
+                    Column(
                         modifier = Modifier
-                            .onGloballyPositioned { containerBounds = it.boundsInRoot() },
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
                     ) {
-                        Column(
+                        Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
+                        MPCardNumberTextField(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(horizontal = 16.dp),
-                        ) {
-                            Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                            MPCardNumberTextField(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .focusRequester(cardNumberFocusRequester),
-                                state = cardNumberPCIState,
-                                isFocused = viewState.cardNumberState.isFocused,
-                                showPlaceHolder = viewState.cardNumberState.showPlaceHolder,
-                                error = viewState.cardNumberState.error,
-                                enabled = viewState.cardNumberState.enabled,
-                                label = viewState.cardNumberState.label,
-                                helper = viewState.cardNumberState.helper,
-                                placeHolder = viewState.cardNumberState.placeHolder,
-                                maxLength = viewState.cardNumberState.maxLength,
-                                visualTransformation = MaskVisualTransformation(viewState.cardNumberState.mask),
-                                onEvent = onCardNumberEvent,
-                            )
+                                .focusRequester(cardNumberFocusRequester),
+                            state = cardNumberPCIState,
+                            isFocused = viewState.cardNumberState.isFocused,
+                            showPlaceHolder = viewState.cardNumberState.showPlaceHolder,
+                            error = viewState.cardNumberState.error,
+                            enabled = viewState.cardNumberState.enabled,
+                            label = viewState.cardNumberState.label,
+                            helper = viewState.cardNumberState.helper,
+                            placeHolder = viewState.cardNumberState.placeHolder,
+                            maxLength = viewState.cardNumberState.maxLength,
+                            visualTransformation = MaskVisualTransformation(viewState.cardNumberState.mask),
+                            onEvent = onCardNumberEvent,
+                        )
 
-                            if (viewState.cardHolderState.show) {
-                                Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                                MPSimpleTextField(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    state = cardHolderPCIState,
-                                    isFocused = viewState.cardHolderState.isFocused,
-                                    showPlaceHolder = viewState.cardHolderState.showPlaceHolder,
-                                    error = viewState.cardHolderState.error,
-                                    enabled = viewState.cardHolderState.enabled,
-                                    label = viewState.cardHolderState.label,
-                                    helper = viewState.cardHolderState.helper,
-                                    placeHolder = viewState.cardHolderState.placeHolder,
-                                    onEvent = onCardHolderEvent,
+                        if (viewState.cardHolderState.show) {
+                            Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
+                            MPSimpleTextField(
+                                modifier = Modifier.fillMaxWidth(),
+                                state = cardHolderPCIState,
+                                isFocused = viewState.cardHolderState.isFocused,
+                                showPlaceHolder = viewState.cardHolderState.showPlaceHolder,
+                                error = viewState.cardHolderState.error,
+                                enabled = viewState.cardHolderState.enabled,
+                                label = viewState.cardHolderState.label,
+                                helper = viewState.cardHolderState.helper,
+                                placeHolder = viewState.cardHolderState.placeHolder,
+                                onEvent = onCardHolderEvent,
+                            )
+                        }
+
+                        Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
+                        MPExpirationDateTextField(
+                            state = expirationDatePCIState,
+                            isFocused = viewState.expirationDateState.isFocused,
+                            showPlaceHolder = viewState.expirationDateState.showPlaceHolder,
+                            error = viewState.expirationDateState.error,
+                            enabled = viewState.expirationDateState.enabled,
+                            label = viewState.expirationDateState.label,
+                            helper = viewState.expirationDateState.helper,
+                            placeHolder = viewState.expirationDateState.placeHolder,
+                            onEvent = onExpirationDateEvent,
+                        )
+
+                        if (!viewState.secureCodeState.optional) {
+                            Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
+                            Box {
+                                MPSecurityCodeTextField(
+                                    state = securityCodePCIState,
+                                    securityCodeSize = viewState.secureCodeState.maxLength,
+                                    isFocused = viewState.secureCodeState.isFocused,
+                                    showPlaceHolder = viewState.secureCodeState.showPlaceHolder,
+                                    error = viewState.secureCodeState.error,
+                                    enabled = viewState.secureCodeState.enabled,
+                                    label = viewState.secureCodeState.label,
+                                    helper = viewState.secureCodeState.helper,
+                                    placeHolder = viewState.secureCodeState.placeHolder,
+                                    onClickTooltip = onTooltipClick,
+                                    onEvent = onSecurityCodeEvent,
                                 )
-                            }
-
-                            Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                            MPExpirationDateTextField(
-                                state = expirationDatePCIState,
-                                isFocused = viewState.expirationDateState.isFocused,
-                                showPlaceHolder = viewState.expirationDateState.showPlaceHolder,
-                                error = viewState.expirationDateState.error,
-                                enabled = viewState.expirationDateState.enabled,
-                                label = viewState.expirationDateState.label,
-                                helper = viewState.expirationDateState.helper,
-                                placeHolder = viewState.expirationDateState.placeHolder,
-                                onEvent = onExpirationDateEvent,
-                            )
-
-                            if (!viewState.secureCodeState.optional) {
-                                Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                                Box(
-                                    modifier = Modifier.onGloballyPositioned {
-                                        securityCodeBounds = it.boundsInRoot()
-                                    },
-                                ) {
-                                    MPSecurityCodeTextField(
-                                        state = securityCodePCIState,
-                                        securityCodeSize = viewState.secureCodeState.maxLength,
-                                        isFocused = viewState.secureCodeState.isFocused,
-                                        showPlaceHolder = viewState.secureCodeState.showPlaceHolder,
-                                        error = viewState.secureCodeState.error,
-                                        enabled = viewState.secureCodeState.enabled,
-                                        label = viewState.secureCodeState.label,
-                                        helper = viewState.secureCodeState.helper,
-                                        placeHolder = viewState.secureCodeState.placeHolder,
-                                        onClickTooltip = onTooltipClick,
-                                        onEvent = onSecurityCodeEvent,
+                                if (viewState.showTooltip) {
+                                    MPPopover(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .layout { measurable, constraints ->
+                                                val placeable = measurable.measure(constraints)
+                                                layout(placeable.width, 0) {
+                                                    placeable.placeRelative(0, -placeable.height)
+                                                }
+                                            },
+                                        description = viewState.secureCodeState.messageTooltip,
+                                        onDismiss = onTooltipClick,
                                     )
                                 }
-                            }
-
-                            if (viewState.identificationTypeState.show) {
-                                Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
-                                viewState.identificationTypeState.identificationTypes?.let { types ->
-                                    MPIdentificationTextField(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        state = identificationPCIState,
-                                        identificationTypes = types,
-                                        selectedIdentificationType = viewState.identificationTypeState.selected,
-                                        isFocused = viewState.identificationTypeState.isFocused,
-                                        showPlaceHolder = viewState.identificationTypeState.showPlaceHolder,
-                                        error = viewState.identificationTypeState.error,
-                                        enabled = viewState.identificationTypeState.enabled,
-                                        label = viewState.identificationTypeState.label,
-                                        helper = viewState.identificationTypeState.helper,
-                                        placeHolder = viewState.identificationTypeState.placeHolder,
-                                        onEvent = onIdentificationEvent,
-                                    )
-                                }
-                                Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
                             }
                         }
-                        if (viewState.showTooltip && securityCodeBounds != Rect.Zero && containerBounds != Rect.Zero) {
-                            val relativeSecurityCodeTop =
-                                securityCodeBounds.top - containerBounds.top
-                            val popoverY = (relativeSecurityCodeTop - popoverHeightPx).roundToInt()
-                                .coerceAtLeast(0)
-                            Box(
-                                modifier = Modifier
-                                    .align(Alignment.TopCenter)
-                                    .offset { IntOffset(0, popoverY) },
-                            ) {
-                                MPPopover(
-                                    description = viewState.secureCodeState.messageTooltip,
-                                    onDismiss = onTooltipClick,
+
+                        if (viewState.identificationTypeState.show) {
+                            Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
+                            viewState.identificationTypeState.identificationTypes?.let { types ->
+                                MPIdentificationTextField(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    state = identificationPCIState,
+                                    identificationTypes = types,
+                                    selectedIdentificationType = viewState.identificationTypeState.selected,
+                                    isFocused = viewState.identificationTypeState.isFocused,
+                                    showPlaceHolder = viewState.identificationTypeState.showPlaceHolder,
+                                    error = viewState.identificationTypeState.error,
+                                    enabled = viewState.identificationTypeState.enabled,
+                                    label = viewState.identificationTypeState.label,
+                                    helper = viewState.identificationTypeState.helper,
+                                    placeHolder = viewState.identificationTypeState.placeHolder,
+                                    onEvent = onIdentificationEvent,
                                 )
                             }
+                            Spacer(Modifier.size(MercadoPagoAndesTheme.spacing.gap.xsmall))
                         }
                     }
                 }

--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
@@ -1,5 +1,6 @@
 package com.mercadopago.sdk.android.components
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -37,26 +38,29 @@ import com.mercadopago.sdk.android.foundation.theme.MercadoPagoTheme
 /**
  * A header component that provides different layout styles for page headers.
  *
- * The component supports  expanded header (back button, large title, optional subtitle) is placed
- *  above the content and scrolls up with it. A collapsed bar (back + medium title) is shown as an overlay
- *  at the top, fading from transparent to fully visible as the user scrolls.
+ * Displays an expanded header (back button, large title, optional subtitle) above the content that
+ * scrolls up with it. A collapsed bar (back + medium title) is shown as an overlay at the top,
+ * fading from transparent to fully visible as the user scrolls.
  *
  * @param modifier Modifier to be applied to the header container.
- * @param title The title text displayed in the header. Required parameter.
+ * @param scrollState The [ScrollState] driving the internal scroll. Hoist this state when callers
+ * need to observe or react to the scroll offset (e.g. to position overlays relative to scrollable
+ * content). Defaults to an internally-owned [rememberScrollState].
+ * @param title The title text displayed in the header.
  * @param subtitle Optional subtitle text displayed below the title.
  * @param onBackClick Callback invoked when the back button is clicked.
- * @param content The composable content to display below the header.
- * this content is placed inside the same scroll as the expanded header; do not add verticalScroll to it.
+ * @param content Composable content placed below the expanded title, inside the same scroll
+ * container. Do not apply [androidx.compose.foundation.verticalScroll] to this content.
  */
 @Composable
 fun MPHeader(
     modifier: Modifier = Modifier,
+    scrollState: ScrollState = rememberScrollState(),
     title: String,
     subtitle: String = "",
     onBackClick: () -> Unit = {},
     content: @Composable () -> Unit,
 ) {
-    val scrollState = rememberScrollState()
     var titleBlockHeightPx by remember { mutableFloatStateOf(0f) }
     val scrollOffset = scrollState.value.toFloat()
     val progress = scrollOffset.scrollProgressRatio(titleBlockHeightPx)


### PR DESCRIPTION
# Pull Request
Popover movement when scroll
<!--Provide the title of the pull request-->
## Ticket or Issue link
3818
<!--Provide link for your issue or ticket that describes this pull request-->

## Description
  - Fix `MPPopover` floating above `MPSecurityCodeTextField` during scroll: replaced absolute-coordinate approach (`boundsInRoot` + `offset`) — which became stale after
  `graphicsLayer` scroll translations — with direct parent-relative positioning using `Modifier.layout`, making the popover report zero height to the `Column` and render exactly
  above the security code field regardless of scroll state or keyboard presence
  - `MPHeader`: hoisted internal `ScrollState` as an optional parameter (`scrollState: ScrollState = rememberScrollState()`) to allow callers to observe scroll position; no
  breaking change (default value preserved)
  - Updated `MPHeader` KDoc to document the new parameter

## Checklist
- [ ] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [ ] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<!---
Provide videos or screenshots. You can change their size in the src
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>
-->
![popover](https://github.com/user-attachments/assets/f712135c-f3c7-4aab-bfff-06fb5a7385cb)
