### PR TITLE
[3845](Fix): Adjusted popover init message

### DIFF
--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/factory/CardPaymentScreenStateFactory.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/factory/CardPaymentScreenStateFactory.kt
@@ -44,11 +44,12 @@ internal class CardPaymentScreenStateFactory(
             placeHolder = stringProvider.getString(R.string.card_form_expiration_placeholder),
         )
 
-    private fun createSecurityCodeState() =
+    private fun createSecurityCodeState(): SecurityCodeState =
         SecurityCodeState(
             label = stringProvider.getString(R.string.card_form_security_label),
             placeHolder = stringProvider.getString(R.string.card_form_security_placeholder_three_digits),
-            messageTooltip = stringProvider.getString(R.string.card_form_security_code_tooltip_back),
+            messageTooltip = stringProvider.getString(R.string.card_form_security_code_tooltip_back)
+                .format(SecurityCodeState().maxLength),
         )
 
     private fun createIdentificationTypeState() =


### PR DESCRIPTION
# Pull Request
<!--Provide the title of the pull request-->
## Ticket or Issue link
<!--Provide link for your issue or ticket that describes this pull request-->

## Description
  - Fixed MPPopover tooltip showing unformatted %d placeholder on initial screen load
  - The initial SecurityCodeState was built with a raw string from resources, without formatting the digit count argument
  - Fixed by reading maxLength from SecurityCodeState's default value and applying .format() when building the initial state in CardPaymentScreenStateFactory


## Checklist
- [ ] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [ ] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<!---
Provide videos or screenshots. You can change their size in the src
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>
-->

|andes|depois|
| :---: | :---: |
|    <img width="339" height="116" alt="Captura de Tela 2026-04-02 às 11 28 57" src="https://github.com/user-attachments/assets/b82d7abf-4010-4ddf-9381-a04df3f0c231" /> |  ![popover_init](https://github.com/user-attachments/assets/4490ba95-fc51-44d8-8758-6cc2588baa06) |
