### PR TITLE
[3848](Fix): Change sdk initialization

### DIFF
--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckout.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckout.kt
@@ -35,7 +35,9 @@ class MercadoPagoCheckout private constructor(
     ) {
         CheckoutCallbackHolder.setCallback(callback)
         Checkout.getInstance(context).koin.get<CheckoutThemePreferences>().apply {
-            setCurrentAppearance(checkoutAppearance?.appearance ?: MercadoPagoThemeAppearance.System)
+            setCurrentAppearance(
+                checkoutAppearance?.appearance ?: MercadoPagoThemeAppearance.System,
+            )
             setCurrentThemeScheme(checkoutAppearance?.theme ?: MercadoPagoThemes.Default)
         }
         val intent = Intent(context, CheckoutActivity::class.java).apply {

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckout.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckout.kt
@@ -26,7 +26,7 @@ class MercadoPagoCheckout private constructor(
     private val context: Context,
     private val checkoutConfiguration: CheckoutConfiguration,
     private val checkoutAppearance: CheckoutAppearance?,
-    private val koin: Koin = Checkout.getInstance().koin,
+    private val koin: Koin = Checkout.getInstance(context).koin,
 ) {
     /**
      * Launches the checkout

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckout.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckout.kt
@@ -14,7 +14,6 @@ import com.mercadopago.sdk.android.checkout.domain.interactor.Checkout
 import com.mercadopago.sdk.android.checkout.presentation.CheckoutActivity
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoThemeAppearance
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoThemes
-import org.koin.core.Koin
 
 internal const val EXTRA_CONFIGURATION = "extra_configuration"
 
@@ -26,7 +25,6 @@ class MercadoPagoCheckout private constructor(
     private val context: Context,
     private val checkoutConfiguration: CheckoutConfiguration,
     private val checkoutAppearance: CheckoutAppearance?,
-    private val koin: Koin = Checkout.getInstance(context).koin,
 ) {
     /**
      * Launches the checkout
@@ -36,7 +34,7 @@ class MercadoPagoCheckout private constructor(
         callback: (MercadoPagoCheckoutResult) -> Unit,
     ) {
         CheckoutCallbackHolder.setCallback(callback)
-        koin.get<CheckoutThemePreferences>().apply {
+        Checkout.getInstance(context).koin.get<CheckoutThemePreferences>().apply {
             setCurrentAppearance(checkoutAppearance?.appearance ?: MercadoPagoThemeAppearance.System)
             setCurrentThemeScheme(checkoutAppearance?.theme ?: MercadoPagoThemes.Default)
         }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/di/CheckoutModulesProvider.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/di/CheckoutModulesProvider.kt
@@ -1,15 +1,15 @@
 package com.mercadopago.sdk.android.checkout.di
 
+import android.content.Context
 import com.mercadopago.sdk.android.core.di.CoreKoinFactory
 import com.mercadopago.sdk.android.core.di.CoreKoinModuleProvider
-import com.mercadopago.sdk.android.di.MercadoPagoKoinComponent
 import org.koin.core.Koin
 import org.koin.core.module.Module
 
-internal class CheckoutModulesProvider : CoreKoinModuleProvider, MercadoPagoKoinComponent {
-    override val koinApp: Koin = CoreKoinFactory.setKoinModules(
-        koin = getKoin(),
-        modules = provideModules(),
+internal class CheckoutModulesProvider(context: Context) : CoreKoinModuleProvider {
+    override val koinApp: Koin = CoreKoinFactory.createKoinApp(
+        provider = this,
+        context = context,
     )
 
     override fun provideModules(): List<Module> {

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/interactor/Checkout.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/interactor/Checkout.kt
@@ -34,8 +34,9 @@ class Checkout internal constructor(
 
         /**
          * @suppress
-         * Only for internal usage. DO NOT USE IN PRODUCTION.
-         * Clear the current instance of the Checkout for testing purposes.
+         * Closes the current Koin session and clears the instance.
+         * Called by CheckoutActivity.onDestroy to clean up after each session.
+         * Also available for testing purposes.
          */
         @RestrictTo(RestrictTo.Scope.LIBRARY)
         fun clearInstance() {

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/interactor/Checkout.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/interactor/Checkout.kt
@@ -39,7 +39,10 @@ class Checkout internal constructor(
          */
         @RestrictTo(RestrictTo.Scope.LIBRARY)
         fun clearInstance() {
-            instance = null
+            synchronized(this) {
+                instance?.koin?.close()
+                instance = null
+            }
         }
     }
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/interactor/Checkout.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/interactor/Checkout.kt
@@ -1,5 +1,6 @@
 package com.mercadopago.sdk.android.checkout.domain.interactor
 
+import android.content.Context
 import androidx.annotation.RestrictTo
 import com.mercadopago.sdk.android.checkout.di.CheckoutModulesProvider
 import org.koin.core.Koin
@@ -19,10 +20,12 @@ class Checkout internal constructor(
         @Volatile
         private var instance: Checkout? = null
 
-        internal fun getInstance(): Checkout {
+        internal fun getInstance(
+            context: Context,
+        ): Checkout {
             return instance ?: synchronized(this) {
                 instance ?: Checkout(
-                    koin = CheckoutModulesProvider().koinApp,
+                    koin = CheckoutModulesProvider(context.applicationContext).koinApp,
                 ).also {
                     instance = it
                 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/CheckoutActivity.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/CheckoutActivity.kt
@@ -44,4 +44,9 @@ internal class CheckoutActivity : ComponentActivity() {
             }
         }
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Checkout.clearInstance()
+    }
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/CheckoutActivity.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/CheckoutActivity.kt
@@ -15,7 +15,7 @@ import com.mercadopago.sdk.android.foundation.theme.MercadoPagoThemes
 import org.koin.compose.KoinContext
 
 internal class CheckoutActivity : ComponentActivity() {
-    private val checkoutThemePreferences: CheckoutThemePreferences by Checkout.getInstance().koin.inject()
+    private val checkoutThemePreferences: CheckoutThemePreferences by Checkout.getInstance(this).koin.inject()
 
     override fun onCreate(
         savedInstanceState: Bundle?,
@@ -34,7 +34,7 @@ internal class CheckoutActivity : ComponentActivity() {
         }
 
         setContent {
-            KoinContext(context = Checkout.getInstance().koin) {
+            KoinContext(context = Checkout.getInstance(this).koin) {
                 MercadoPagoTheme(
                     theme = MercadoPagoThemes.Default,
                     appearance = checkoutThemePreferences.getCurrentAppearance(),

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/CheckoutActivity.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/CheckoutActivity.kt
@@ -11,7 +11,6 @@ import com.mercadopago.sdk.android.checkout.domain.callback.CheckoutCallbackHold
 import com.mercadopago.sdk.android.checkout.domain.interactor.Checkout
 import com.mercadopago.sdk.android.checkout.presentation.controller.MPCardPayment
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoTheme
-import com.mercadopago.sdk.android.foundation.theme.MercadoPagoThemes
 import org.koin.compose.KoinContext
 
 internal class CheckoutActivity : ComponentActivity() {
@@ -36,7 +35,7 @@ internal class CheckoutActivity : ComponentActivity() {
         setContent {
             KoinContext(context = Checkout.getInstance(this).koin) {
                 MercadoPagoTheme(
-                    theme = MercadoPagoThemes.Default,
+                    theme = checkoutThemePreferences.getCurrentThemeScheme(),
                     appearance = checkoutThemePreferences.getCurrentAppearance(),
                 ) {
                     MPCardPayment(checkoutConfiguration = checkoutConfiguration)

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/CheckoutModulesProviderTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/CheckoutModulesProviderTest.kt
@@ -66,9 +66,8 @@ internal class CheckoutModulesProviderTest {
         every { context.resources } returns resources
         every { context.createConfigurationContext(any()) } returns context
         every { MercadoPagoSDK.getInstance() } returns mockk<MercadoPagoSDK>(relaxed = true)
-        every { CoreKoinFactory.setKoinModules(any(), any()) } returns mockk()
         every { CoreKoinFactory.createKoinApp(any(), any(), any()) } returns mockk()
-        val modulesProvider = CheckoutModulesProvider()
+        val modulesProvider = CheckoutModulesProvider(context)
         val mercadoPagoSdkModulesProvider = MercadoPagoSdkModulesProvider(
             publicKey = "public_key",
             context = context,

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/interactor/CheckoutTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/interactor/CheckoutTest.kt
@@ -57,6 +57,12 @@ internal class CheckoutTest {
     }
 
     @Test
+    fun `clearInstance is idempotent when no instance exists`() {
+        // Should not throw when called with no active session
+        Checkout.clearInstance()
+    }
+
+    @Test
     fun `clearInstance nulls the instance so next getInstance creates fresh`() {
         Checkout.getInstance(context)
         Checkout.clearInstance()

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/interactor/CheckoutTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/interactor/CheckoutTest.kt
@@ -1,0 +1,72 @@
+package com.mercadopago.sdk.android.checkout.domain.interactor
+
+import android.content.Context
+import com.mercadopago.sdk.android.checkout.di.CheckoutModulesProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.koin.core.Koin
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+
+internal class CheckoutTest {
+    private val context = mockk<Context>(relaxed = true)
+    private val mockKoin = mockk<Koin>(relaxed = true)
+
+    @Before
+    fun setUp() {
+        mockkConstructor(CheckoutModulesProvider::class)
+        every { anyConstructed<CheckoutModulesProvider>().koinApp } returns mockKoin
+        Checkout.clearInstance()
+    }
+
+    @After
+    fun tearDown() {
+        Checkout.clearInstance()
+        unmockkAll()
+    }
+
+    @Test
+    fun `getInstance creates new Checkout when instance is null`() {
+        val checkout = Checkout.getInstance(context)
+
+        assertNotNull(checkout)
+        assertSame(mockKoin, checkout.koin)
+    }
+
+    @Test
+    fun `getInstance returns same instance on repeated calls`() {
+        val first = Checkout.getInstance(context)
+        val second = Checkout.getInstance(context)
+
+        assertSame(first, second)
+    }
+
+    @Test
+    fun `clearInstance closes the Koin`() {
+        Checkout.getInstance(context)
+
+        Checkout.clearInstance()
+
+        verify { mockKoin.close() }
+    }
+
+    @Test
+    fun `clearInstance nulls the instance so next getInstance creates fresh`() {
+        Checkout.getInstance(context)
+        Checkout.clearInstance()
+
+        val freshKoin = mockk<Koin>(relaxed = true)
+        every { anyConstructed<CheckoutModulesProvider>().koinApp } returns freshKoin
+
+        val second = Checkout.getInstance(context)
+
+        assertNotNull(second)
+        assertSame(freshKoin, second.koin)
+    }
+}

--- a/core/src/main/java/com/mercadopago/sdk/android/core/di/KoinModuleProvider.kt
+++ b/core/src/main/java/com/mercadopago/sdk/android/core/di/KoinModuleProvider.kt
@@ -55,9 +55,7 @@ object CoreKoinFactory {
             androidLogger(loggerLevel)
             // Add modules definitions
             modules(provider.provideModules())
-        }.koin.also { koin ->
-            koin.loadModules(provider.provideModules())
-        }
+        }.koin
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
https://mercadolibre.atlassian.net/browse/CHOBK-3848

## Description

- **Isolated Checkout Koin from the shared SDK Koin**: `CheckoutModulesProvider` now creates its own `KoinApplication` via `CoreKoinFactory.createKoinApp` instead of reusing the global SDK Koin. This prevents state leakage between the SDK and the checkout session.
- **Scoped Koin to session lifetime**: `Checkout.getInstance()` now requires a `Context` and lazily creates an isolated Koin per session. `CheckoutActivity.onDestroy()` calls `Checkout.clearInstance()`, which properly closes the Koin instance and frees all associated resources.
- **Fixed Koin resource leak**: `clearInstance()` previously only nulled the singleton reference without calling `koin.close()`, leaving scopes and coroutine contexts alive until GC. Now closes explicitly.
- **Fixed silent theme bug**: `CheckoutActivity` was hardcoding `theme = MercadoPagoThemes.Default`, ignoring the theme scheme configured by the host app. Now reads from `CheckoutThemePreferences`.
- **Removed redundant `loadModules` call**: `CoreKoinFactory.createKoinApp` was registering modules twice (once in the `koinApplication` builder and once via `koin.loadModules`). Removed the duplicate call.

## Checklist
- [ ] I have tested my changes creating a local version (More info in README file).
- [x] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [x] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)