### PR TITLE
[3860](Fix): Design token alignment across MPComponents

### DIFF
--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPBadgeIcon.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPBadgeIcon.kt
@@ -3,7 +3,6 @@ package com.mercadopago.sdk.android.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -46,7 +45,7 @@ fun MPBadgeIcon(
         modifier
             .background(
                 color = color,
-                shape = CircleShape,
+                shape = MercadoPagoTheme.shape.full,
             ),
         tint = MercadoPagoTheme.color.text.inverse,
     )

--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPHeader.kt
@@ -129,7 +129,7 @@ private fun MPHeaderCollapsedTitle(
         Spacer(modifier = Modifier.size(MercadoPagoTheme.spacing.paddings.xmicro))
         MPText(
             text = title,
-            style = MercadoPagoTheme.typography.heading.default.medium,
+            style = MercadoPagoTheme.typography.heading.default.small,
         )
     }
 }

--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPHeaderDefaults.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPHeaderDefaults.kt
@@ -41,16 +41,16 @@ internal fun getMPHeaderDefaults(): MPHeaderDefaults {
     return MPHeaderDefaults(
         colors = MPHeaderColorDefaults(
             backgroundPrimary = MercadoPagoTheme.color.background.primary,
-            backButtonBackground = MercadoPagoTheme.color.surface.primaryActive,
+            backButtonBackground = MercadoPagoTheme.color.interactive.fillQuiet.idle,
             backButtonIcon = MercadoPagoTheme.color.icon.accent,
             titleText = MercadoPagoTheme.color.text.primary,
         ),
         spacing = MPHeaderSpacingDefaults(
-            backButtonCornerRadius = MercadoPagoTheme.radius.xsmall,
+            backButtonCornerRadius = MercadoPagoTheme.radius.medium,
             fadeOverlayExtraHeight = MercadoPagoTheme.spacing.paddings.xtiny,
         ),
         shape = MPHeaderShapeDefaults(
-            backButtonShape = MercadoPagoTheme.shape.xsmall,
+            backButtonShape = MercadoPagoTheme.shape.medium,
         ),
         typography = MPHeaderTypographyDefaults(
             titleExpanded = MercadoPagoTheme.typography.heading.default.huge,

--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPPopover.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPPopover.kt
@@ -52,7 +52,7 @@ fun MPPopover(
 
     Surface(
         modifier = modifier
-            .defaultMinSize(minWidth = 240.dp, minHeight = 86.dp)
+            .defaultMinSize(minWidth = 380.dp, minHeight = 86.dp)
             .padding(defaults.spacing.surfacePadding),
         color = defaults.colors.backgroundColor,
         shape = bubbleShape,
@@ -137,7 +137,7 @@ private fun getPopoverDefaults(): PopoverDefaults {
             closeIconColor = MercadoPagoTheme.color.interactive.icon.idle,
         ),
         spacing = PopoverSpacingDefaults(
-            cornerRadius = MercadoPagoTheme.radius.medium,
+            cornerRadius = MercadoPagoTheme.radius.xlarge,
             pointerWidth = MercadoPagoTheme.spacing.paddings.xtiny,
             pointerHeight = MercadoPagoTheme.spacing.paddings.xnano,
             pointerEndOffset = MercadoPagoTheme.spacing.gap.micro,

--- a/components/src/main/java/com/mercadopago/sdk/android/components/extensions/ModifierExt.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/extensions/ModifierExt.kt
@@ -9,6 +9,7 @@ import com.mercadopago.sdk.android.components.inputs.MPInputDefaults
 internal fun Modifier.addBorder(
     isFocused: Boolean,
     error: Boolean = false,
+    enabled: Boolean = true,
     defaults: MPInputDefaults,
 ): Modifier {
     return border(
@@ -17,7 +18,9 @@ internal fun Modifier.addBorder(
         } else {
             defaults.border.widthIdle
         },
-        color = if (error) {
+        color = if (!enabled) {
+            defaults.colors.borderDisabled
+        } else if (error) {
             defaults.colors.borderError
         } else if (isFocused) {
             defaults.colors.borderActive

--- a/components/src/main/java/com/mercadopago/sdk/android/components/inputs/MPInput.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/inputs/MPInput.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,6 +26,7 @@ import com.mercadopago.sdk.android.foundation.theme.MercadoPagoTheme
 internal fun MPInputDecorationBox(
     isFocused: Boolean,
     error: Boolean,
+    enabled: Boolean = true,
     defaults: MPInputDefaults,
     content: @Composable (RowScope.() -> Unit),
 ) {
@@ -36,9 +36,10 @@ internal fun MPInputDecorationBox(
             .addBorder(
                 isFocused = isFocused,
                 error = error,
+                enabled = enabled,
                 defaults = defaults,
             )
-            .height(OutlinedTextFieldDefaults.MinHeight)
+            .height(MercadoPagoTheme.spacing.paddings.xlarge)
             .padding(horizontal = defaults.spacing.horizontalPadding),
     ) {
         content()

--- a/components/src/main/java/com/mercadopago/sdk/android/components/inputs/MPInputDefaults.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/inputs/MPInputDefaults.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoTheme
 
 internal data class MPInputDefaults(
@@ -16,6 +15,7 @@ internal data class MPInputDefaults(
 internal data class MPInputColorDefaults(
     val borderIdle: Color,
     val borderActive: Color,
+    val borderDisabled: Color,
     val borderError: Color,
     val cursor: Color,
     val textPrimary: Color,
@@ -42,6 +42,7 @@ internal fun getMPInputDefaults(): MPInputDefaults {
         colors = MPInputColorDefaults(
             borderIdle = MercadoPagoTheme.color.interactive.border.idle,
             borderActive = MercadoPagoTheme.color.interactive.border.active,
+            borderDisabled = MercadoPagoTheme.color.border.disabled,
             borderError = MercadoPagoTheme.color.feedback.negative.borderLoud,
             cursor = MercadoPagoTheme.color.interactive.border.active,
             textPrimary = MercadoPagoTheme.color.text.primary,
@@ -52,7 +53,7 @@ internal fun getMPInputDefaults(): MPInputDefaults {
         spacing = MPInputSpacingDefaults(
             labelPadding = MercadoPagoTheme.spacing.paddings.pico,
             helperPadding = MercadoPagoTheme.spacing.paddings.xnano,
-            horizontalPadding = 16.dp,
+            horizontalPadding = MercadoPagoTheme.spacing.paddings.micro,
         ),
         border = MPInputBorderDefaults(
             widthIdle = MercadoPagoTheme.borderWidth.small,

--- a/components/src/main/java/com/mercadopago/sdk/android/components/inputs/MPSimpleTextField.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/inputs/MPSimpleTextField.kt
@@ -69,6 +69,7 @@ fun MPSimpleTextField(
                 MPInputDecorationBox(
                     isFocused = isFocused,
                     error = error.isNotBlank(),
+                    enabled = enabled,
                     defaults = defaults,
                 ) {
                     Box {

--- a/foundation/src/main/java/com/mercadopago/sdk/android/foundation/typography/Typography.kt
+++ b/foundation/src/main/java/com/mercadopago/sdk/android/foundation/typography/Typography.kt
@@ -152,8 +152,8 @@ internal val HeadingHugeNarrow = TextStyle(
 internal val BodySmallDefault = TextStyle(
     fontFamily = InterFontFamily,
     fontWeight = FontWeight.W400,
-    fontSize = 14.sp,
-    lineHeight = 20.sp,
+    fontSize = 12.sp,
+    lineHeight = 16.sp,
     letterSpacing = 0.sp,
 )
 
@@ -161,8 +161,8 @@ internal val BodySmallDefault = TextStyle(
 internal val BodySmallEmphasis = TextStyle(
     fontFamily = InterFontFamily,
     fontWeight = FontWeight.W600,
-    fontSize = 14.sp,
-    lineHeight = 20.sp,
+    fontSize = 12.sp,
+    lineHeight = 16.sp,
     letterSpacing = 0.sp,
 )
 
@@ -170,8 +170,8 @@ internal val BodySmallEmphasis = TextStyle(
 internal val BodySmallTextlink = TextStyle(
     fontFamily = InterFontFamily,
     fontWeight = FontWeight.W600,
-    fontSize = 14.sp,
-    lineHeight = 20.sp,
+    fontSize = 12.sp,
+    lineHeight = 16.sp,
     letterSpacing = 0.sp,
 )
 
@@ -179,8 +179,8 @@ internal val BodySmallTextlink = TextStyle(
 internal val BodyMediumDefault = TextStyle(
     fontFamily = InterFontFamily,
     fontWeight = FontWeight.W400,
-    fontSize = 16.sp,
-    lineHeight = 24.sp,
+    fontSize = 14.sp,
+    lineHeight = 20.sp,
     letterSpacing = 0.sp,
 )
 
@@ -188,8 +188,8 @@ internal val BodyMediumDefault = TextStyle(
 internal val BodyMediumEmphasis = TextStyle(
     fontFamily = InterFontFamily,
     fontWeight = FontWeight.W600,
-    fontSize = 16.sp,
-    lineHeight = 24.sp,
+    fontSize = 14.sp,
+    lineHeight = 20.sp,
     letterSpacing = 0.sp,
 )
 
@@ -197,8 +197,8 @@ internal val BodyMediumEmphasis = TextStyle(
 internal val BodyMediumTextlink = TextStyle(
     fontFamily = InterFontFamily,
     fontWeight = FontWeight.W600,
-    fontSize = 16.sp,
-    lineHeight = 24.sp,
+    fontSize = 14.sp,
+    lineHeight = 20.sp,
     letterSpacing = 0.sp,
 )
 
@@ -206,8 +206,8 @@ internal val BodyMediumTextlink = TextStyle(
 internal val BodyLargeDefault = TextStyle(
     fontFamily = InterFontFamily,
     fontWeight = FontWeight.W400,
-    fontSize = 18.sp,
-    lineHeight = 28.sp,
+    fontSize = 16.sp,
+    lineHeight = 24.sp,
     letterSpacing = 0.sp,
 )
 
@@ -215,8 +215,8 @@ internal val BodyLargeDefault = TextStyle(
 internal val BodyLargeEmphasis = TextStyle(
     fontFamily = InterFontFamily,
     fontWeight = FontWeight.W600,
-    fontSize = 18.sp,
-    lineHeight = 28.sp,
+    fontSize = 16.sp,
+    lineHeight = 24.sp,
     letterSpacing = 0.sp,
 )
 
@@ -224,8 +224,8 @@ internal val BodyLargeEmphasis = TextStyle(
 internal val BodyLargeTextlink = TextStyle(
     fontFamily = InterFontFamily,
     fontWeight = FontWeight.W600,
-    fontSize = 18.sp,
-    lineHeight = 28.sp,
+    fontSize = 16.sp,
+    lineHeight = 24.sp,
     letterSpacing = 0.sp,
 )
 


### PR DESCRIPTION
# Pull Request
Design token alignment across MPComponents
## Ticket or Issue link
3860

## Description
Design token alignment across `components/` and `foundation/` — based on audit against Bricks Nativo (Figma). No new tokens or behaviors introduced; only corrected values and
  token references.                                                                                                                                                                
   
  **Foundation**                                                                                                                                                                   
  - Corrected body typography scale: all sizes were 2sp above Figma spec
    - `body/small` 14sp → 12sp (lh 20sp → 16sp)                                                                                                                                    
    - `body/medium` 16sp → 14sp (lh 24sp → 20sp)                                                                                                                                   
    - `body/large` 18sp → 16sp (lh 28sp → 24sp)                                                                                                                                    
    - Applies to `default`, `emphasis` and `textlink` variants                                                                                                                     
                                                                                                                                                                                   
  **MPHeader**                                                                                                                                                                     
  - Back button background: `color.surface.primaryActive` → `color.interactive.fillQuiet.idle`                                                                                     
  - Back button shape/radius: `shape.xsmall` / `radius.xsmall` → `shape.medium` / `radius.medium` (12dp)                                                                           
  - Collapsed title typography: `heading.default.medium` (20sp) → `heading.default.small` (16sp), aligned with Figma on-scroll spec                                                
                                                                                                                                                                                   
  **MPPopover**                                                                                                                                                                    
  - Surface corner radius: `radius.medium` → `radius.xlarge` (20dp)
  - Min-width: hardcoded `240dp` → `380dp`                                                                                                                                         
                                                                                                                                                                                   
  **MPBadgeIcon**                                                                                                                                                                  
  - Shape: `CircleShape` (hardcoded) → `MercadoPagoTheme.shape.full` (tokenized)                                                                                                   
                                                                                                                                                                                   
  **MPInputDefaults / MPInput / MPSimpleTextField**                                                                                                                                
  - Horizontal padding: hardcoded `16dp` → `spacing.paddings.micro` (12dp)                                                                                                         
  - Disabled border: was using `interactive.border.idle` → now uses `color.border.disabled`; `enabled` propagated through `MPInputDecorationBox` and `addBorder`                   
  - Field height: `OutlinedTextFieldDefaults.MinHeight` (Material3) → `spacing.paddings.xlarge` (56dp)  

## Checklist
- [ ] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [ ] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<!---
Provide videos or screenshots. You can change their size in the src
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>
-->
