### PR TITLE
[4049](Fix): CI - skip non-published dependents in version consistency check

### DIFF
--- a/.circleci/scripts/check-version-consistency.sh
+++ b/.circleci/scripts/check-version-consistency.sh
@@ -49,6 +49,7 @@ done
 ERRORS=""
 for changed in $CHANGED_MODULES; do
   for dependent in ${DEPENDENTS[$changed]:-}; do
+    echo "$PUBLISHED_MODULES" | grep -qw "$dependent" || continue
     if ! echo "$CHANGED_MODULES" | grep -qw "$dependent"; then
       ERRORS="$ERRORS\n  ✗ '$dependent' depends on '$changed' but VERSION_NAME was not bumped"
     fi


### PR DESCRIPTION
## Ticket or Issue link
MPASDK-4049

## Description
The `check-version-consistency.sh` script was failing on the `0.2.2` release merge (BOM bumped to `0.2.3`) because it required version bumps on modules that are not published.

**Root cause:** the `DEPENDENTS` map is built from every `*/build.gradle.kts`, including internal-only modules (`checkout`, `components`, `foundation`, `mp-extended`). Meanwhile `PUBLISHED_MODULES` is derived only from BOM constraints (`core, analytics, sdk-android, core-methods, sdk-android-bom`). The error loop did not filter dependents by publication status, so bumping any BOM module wrongly required bumping internal dependents too.

**Fix:** skip dependents that are not in `PUBLISHED_MODULES` when reporting consistency errors. No checkout/components/foundation/mp-extended version is touched.

Simulated against `c775d56e` (release 0.2.2 commit): the check now passes.

## Checklist
- [x] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [x] New and existing unit tests pass locally with my changes.
- [x] Verify that you are merged with the latest in develop.
- [x] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.