### PR TITLE
[Feature] Implement generic builder

### DIFF
--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckout.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckout.kt
@@ -11,6 +11,7 @@ import com.mercadopago.sdk.android.checkout.data.preferences.CheckoutThemePrefer
 import com.mercadopago.sdk.android.checkout.domain.callback.CheckoutCallbackHolder
 import com.mercadopago.sdk.android.checkout.domain.callback.MercadoPagoCheckoutResult
 import com.mercadopago.sdk.android.checkout.domain.interactor.Checkout
+import com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData
 import com.mercadopago.sdk.android.checkout.presentation.CheckoutActivity
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoThemes
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoUserInterfaceStyle
@@ -18,20 +19,25 @@ import com.mercadopago.sdk.android.foundation.theme.MercadoPagoUserInterfaceStyl
 internal const val EXTRA_CONFIGURATION = "extra_configuration"
 
 /**
- * MercadoPagoCheckout class, used to configure the checkout
+ * MercadoPagoCheckout class, used to configure the checkout.
+ *
+ * The type parameter [T] is inferred from the [CheckoutType] passed to [Builder],
+ * so the callback in [show] receives a typed [MercadoPagoCheckoutResult] —
+ * no runtime cast needed to access payment-specific fields.
  */
 @Stable
-class MercadoPagoCheckout private constructor(
+class MercadoPagoCheckout<T : MPPaymentData> private constructor(
     private val context: Context,
     private val checkoutConfiguration: CheckoutConfiguration,
     private val checkoutAppearance: CheckoutAppearance?,
 ) {
     /**
-     * Launches the checkout
-     * @param callback Lambda to be invoked when checkout completes with the result
+     * Launches the checkout.
+     * @param callback Lambda to be invoked when checkout completes with the result.
+     * [MercadoPagoCheckoutResult.Success.paymentData] is already the concrete [T] subtype.
      */
     fun show(
-        callback: (MercadoPagoCheckoutResult) -> Unit,
+        callback: (MercadoPagoCheckoutResult<T>) -> Unit,
     ) {
         CheckoutCallbackHolder.setCallback(callback)
         Checkout.getInstance(context).koin.get<CheckoutThemePreferences>().apply {
@@ -47,14 +53,15 @@ class MercadoPagoCheckout private constructor(
     }
 
     /**
-     * Builder for MercadoPagoCheckout
+     * Builder for MercadoPagoCheckout.
      * @param context Context
-     * @param checkoutType CheckoutType
+     * @param checkoutType CheckoutType — determines [T] and therefore the type of
+     * [MercadoPagoCheckoutResult.Success.paymentData] delivered to [show]'s callback.
      * @param checkoutAppearance CheckoutAppearance
      */
-    class Builder(
+    class Builder<T : MPPaymentData>(
         private val context: Context,
-        private val checkoutType: CheckoutType,
+        private val checkoutType: CheckoutType<T>,
         private val checkoutAppearance: CheckoutAppearance? = CheckoutAppearance(
             theme = MercadoPagoThemes.Default,
             style = MercadoPagoUserInterfaceStyle.System,
@@ -73,7 +80,7 @@ class MercadoPagoCheckout private constructor(
         /**
          * Builds the MercadoPagoCheckout
          */
-        fun build(): MercadoPagoCheckout =
+        fun build(): MercadoPagoCheckout<T> =
             MercadoPagoCheckout(
                 context = context,
                 checkoutAppearance = checkoutAppearance,

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/CheckoutType.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/CheckoutType.kt
@@ -1,24 +1,29 @@
 package com.mercadopago.sdk.android.checkout.core.model
 
 import android.os.Parcelable
+import com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData
 import kotlinx.parcelize.Parcelize
 
 /**
- * CheckoutType enum, used to configure the checkout type
+ * CheckoutType enum, used to configure the checkout type.
+ * The type parameter [T] determines the [com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData]
+ * subtype returned in [com.mercadopago.sdk.android.checkout.domain.callback.MercadoPagoCheckoutResult.Success].
  */
-sealed class CheckoutType : Parcelable {
+sealed class CheckoutType<out T : MPPaymentData> : Parcelable {
     /**
-     * CardSave class, used to configure the card form
+     * CardSave class, used to configure the card form.
+     * On success, delivers [MPPaymentData.CardSave].
      */
     @Parcelize
-    object CardSave : CheckoutType()
+    object CardSave : CheckoutType<MPPaymentData.CardSave>()
 
     /**
-     * CardTransaction class, used to configure the card transaction
-     * @param cardFormConfiguration Order
+     * CardTransaction class, used to configure the card transaction.
+     * On success, delivers [MPPaymentData.CardTransaction].
+     * @param order Order
      */
     @Parcelize
     data class CardTransaction(
-        val cardFormConfiguration: Order = Order(),
-    ) : CheckoutType()
+        val order: Order = Order(),
+    ) : CheckoutType<MPPaymentData.CardTransaction>()
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/CheckoutType.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/CheckoutType.kt
@@ -24,6 +24,6 @@ sealed class CheckoutType<out T : MPPaymentData> : Parcelable {
      */
     @Parcelize
     data class CardTransaction(
-        val order: Order = Order(),
+        val order: Order,
     ) : CheckoutType<MPPaymentData.CardTransaction>()
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/Order.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/Order.kt
@@ -12,6 +12,6 @@ import java.math.BigDecimal
  */
 @Parcelize
 data class Order(
-    val amount: BigDecimal? = null,
-    val payer: Payer? = null,
+    val amount: BigDecimal,
+    val payer: Payer,
 ) : CheckoutTypeConfiguration, Parcelable

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/internal/CheckoutConfiguration.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/internal/CheckoutConfiguration.kt
@@ -7,6 +7,6 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class CheckoutConfiguration(
-    val checkoutType: CheckoutType,
+    val checkoutType: CheckoutType<*>,
     val paymentMethods: List<PaymentMethod>,
 ) : Parcelable

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/internal/CheckoutConfigurationExtensions.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/internal/CheckoutConfigurationExtensions.kt
@@ -8,7 +8,7 @@ internal const val AMOUNT_DEFAULT = "0"
 
 internal fun CheckoutConfiguration.getCardFormAmount() =
     (checkoutType as? CheckoutType.CardTransaction)
-        ?.cardFormConfiguration
+        ?.order
         ?.amount
 
 internal fun CheckoutConfiguration.getCardFormAmountOrZero(): String =

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/callback/CheckoutCallbackHolder.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/callback/CheckoutCallbackHolder.kt
@@ -1,13 +1,16 @@
 package com.mercadopago.sdk.android.checkout.domain.callback
 
+import com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData
+
 internal object CheckoutCallbackHolder {
-    private var callback: ((MercadoPagoCheckoutResult) -> Unit)? = null
+    private var callback: ((MercadoPagoCheckoutResult<*>) -> Unit)? = null
     private var activityCallback: (() -> Unit)? = null
 
-    fun setCallback(
-        callback: ((MercadoPagoCheckoutResult) -> Unit)?,
+    fun <T : MPPaymentData> setCallback(
+        callback: ((MercadoPagoCheckoutResult<T>) -> Unit)?,
     ) {
-        this.callback = callback
+        @Suppress("UNCHECKED_CAST")
+        this.callback = callback as? ((MercadoPagoCheckoutResult<*>) -> Unit)
     }
 
     fun setActivityCallback(
@@ -17,7 +20,7 @@ internal object CheckoutCallbackHolder {
     }
 
     fun notify(
-        result: MercadoPagoCheckoutResult,
+        result: MercadoPagoCheckoutResult<*>,
     ) {
         activityCallback?.invoke()
         callback?.invoke(result)

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/callback/MercadoPagoCheckoutResult.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/callback/MercadoPagoCheckoutResult.kt
@@ -7,25 +7,30 @@ import com.mercadopago.sdk.android.checkout.domain.model.UserCancelledContext
 /**
  * Sealed interface representing the possible outcomes of a checkout flow.
  *
+ * The type parameter [T] is inferred from the [com.mercadopago.sdk.android.checkout.core.model.CheckoutType]
+ * passed to the builder, so [Success.paymentData] is already the concrete subtype — no `when` required.
+ *
  * Implementations:
  * - [Success] Checkout completed successfully with payment data.
  * - [Error] Checkout failed due to a card form or payment error.
  * - [UserCancelled] User explicitly cancelled the checkout.
  */
-interface MercadoPagoCheckoutResult {
+interface MercadoPagoCheckoutResult<out T : MPPaymentData> {
     /**
      * Checkout completed successfully.
      *
      * @property paymentData The payment data resulting from the successful checkout.
+     * The concrete type matches the [com.mercadopago.sdk.android.checkout.core.model.CheckoutType]
+     * configured in the builder.
      */
-    data class Success(val paymentData: MPPaymentData) : MercadoPagoCheckoutResult
+    data class Success<T : MPPaymentData>(val paymentData: T) : MercadoPagoCheckoutResult<T>
 
     /**
      * Checkout failed with an error from the card form brick.
      *
      * @property error Details of the error that occurred.
      */
-    data class Error(val error: MercadoPagoCheckoutError) : MercadoPagoCheckoutResult
+    data class Error(val error: MercadoPagoCheckoutError) : MercadoPagoCheckoutResult<Nothing>
 
     /**
      * User cancelled the checkout flow before completion.
@@ -33,5 +38,5 @@ interface MercadoPagoCheckoutResult {
      * @property context Information about the form state when cancelled, including
      * which fields were filled, empty, incomplete, or invalid
      */
-    data class UserCancelled(val context: UserCancelledContext) : MercadoPagoCheckoutResult
+    data class UserCancelled(val context: UserCancelledContext) : MercadoPagoCheckoutResult<Nothing>
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModel.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModel.kt
@@ -425,30 +425,37 @@ internal class CardPaymentViewModel(
                         documentType = buyerIdentification.type,
                         documentNumber = buyerIdentification.number,
                     )
-                    val paymentData = when (checkoutConfiguration?.checkoutType) {
-                        is CheckoutType.CardSave -> MPPaymentData.CardSave(
-                            token = cardToken.token,
-                            paymentMethodId = viewState.value.paymentState.paymentMethodId.orEmpty(),
-                            paymentTypeId = viewState.value.paymentState.paymentTypeId.orEmpty(),
-                            issuerId = viewState.value.cardIssuers.firstOrNull()?.id,
-                            payer = payer,
-                        )
-                        is CheckoutType.CardTransaction, null -> MPPaymentData.CardTransaction(
-                            transactionAmount = checkoutConfiguration?.getCardFormAmount(),
-                            installment = 1,
-                            paymentMethodId = viewState.value.paymentState.paymentMethodId.orEmpty(),
-                            paymentTypeId = viewState.value.paymentState.paymentTypeId.orEmpty(),
-                            issuerId = viewState.value.cardIssuers.firstOrNull()?.id,
-                            payer = payer,
-                        )
-                    }
                     analyticsTracker.trackSubmit(
                         cardBrand = viewState.value.paymentState.paymentMethodId.orEmpty(),
                         transactionAmount = checkoutConfiguration?.getCardFormAmount()?.toDouble() ?: 0.0,
                         issuer = viewState.value.cardIssuers.firstOrNull()?.id.orEmpty(),
                         paymentTypeId = viewState.value.paymentState.paymentTypeId.orEmpty(),
                     )
-                    CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.Success(paymentData))
+                    when (checkoutConfiguration?.checkoutType) {
+                        is CheckoutType.CardSave -> CheckoutCallbackHolder.notify(
+                            MercadoPagoCheckoutResult.Success(
+                                MPPaymentData.CardSave(
+                                    token = cardToken.token,
+                                    paymentMethodId = viewState.value.paymentState.paymentMethodId.orEmpty(),
+                                    paymentTypeId = viewState.value.paymentState.paymentTypeId.orEmpty(),
+                                    issuerId = viewState.value.cardIssuers.firstOrNull()?.id,
+                                    payer = payer,
+                                ),
+                            ),
+                        )
+                        is CheckoutType.CardTransaction, null -> CheckoutCallbackHolder.notify(
+                            MercadoPagoCheckoutResult.Success(
+                                MPPaymentData.CardTransaction(
+                                    transactionAmount = checkoutConfiguration?.getCardFormAmount(),
+                                    installment = 1,
+                                    paymentMethodId = viewState.value.paymentState.paymentMethodId.orEmpty(),
+                                    paymentTypeId = viewState.value.paymentState.paymentTypeId.orEmpty(),
+                                    issuerId = viewState.value.cardIssuers.firstOrNull()?.id,
+                                    payer = payer,
+                                ),
+                            ),
+                        )
+                    }
                 },
                 onError = { checkoutError ->
                     analyticsTracker.trackSubmitError(checkoutError)

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckoutTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckoutTest.kt
@@ -10,6 +10,7 @@ import com.mercadopago.sdk.android.checkout.di.CheckoutModulesProvider
 import com.mercadopago.sdk.android.checkout.domain.callback.CheckoutCallbackHolder
 import com.mercadopago.sdk.android.checkout.domain.callback.MercadoPagoCheckoutResult
 import com.mercadopago.sdk.android.checkout.domain.interactor.Checkout
+import com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoThemes
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoUserInterfaceStyle
 import io.mockk.Runs
@@ -37,7 +38,7 @@ internal class MercadoPagoCheckoutTest {
     fun setUp() {
         mockkObject(CheckoutCallbackHolder)
         mockkConstructor(CheckoutModulesProvider::class, Intent::class)
-        every { CheckoutCallbackHolder.setCallback(any()) } just Runs
+        every { CheckoutCallbackHolder.setCallback<MPPaymentData.CardSave>(any()) } just Runs
         every { anyConstructed<CheckoutModulesProvider>().koinApp } returns mockKoin
         every { mockKoin.get<CheckoutThemePreferences>() } returns mockThemePreferences
         every { anyConstructed<Intent>().putExtra(any<String>(), any<Parcelable>()) } returns mockk(relaxed = true)
@@ -69,7 +70,7 @@ internal class MercadoPagoCheckoutTest {
     @Test
     fun `when show called then setCallback is called with provided callback`() {
         val checkout = buildCheckout()
-        val callback: (MercadoPagoCheckoutResult) -> Unit = {}
+        val callback: (MercadoPagoCheckoutResult<MPPaymentData.CardSave>) -> Unit = {}
 
         checkout.show(callback)
 

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/CheckoutModulesProviderTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/CheckoutModulesProviderTest.kt
@@ -6,6 +6,7 @@ import android.content.res.Configuration
 import com.google.gson.Gson
 import com.mercadopago.sdk.android.checkout.core.model.CheckoutType
 import com.mercadopago.sdk.android.checkout.core.model.Order
+import com.mercadopago.sdk.android.checkout.core.model.Payer
 import com.mercadopago.sdk.android.checkout.core.model.internal.CheckoutConfiguration
 import com.mercadopago.sdk.android.checkout.data.preferences.CheckoutThemePreferences
 import com.mercadopago.sdk.android.checkout.domain.usecase.GetCardBinUseCase
@@ -31,6 +32,7 @@ import org.koin.dsl.module
 import org.koin.test.check.checkModules
 import org.koin.test.mock.MockProvider
 import org.koin.test.verify.verify
+import java.math.BigDecimal
 import kotlin.test.Test
 
 internal class CheckoutModulesProviderTest {
@@ -69,7 +71,7 @@ internal class CheckoutModulesProviderTest {
         )
 
         val checkoutConfiguration = CheckoutConfiguration(
-            checkoutType = CheckoutType.CardTransaction(Order()),
+            checkoutType = CheckoutType.CardTransaction(Order(amount = BigDecimal.TEN, payer = Payer(email = ""))),
             paymentMethods = emptyList(),
         )
         val module = module {

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/DataModuleTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/DataModuleTest.kt
@@ -5,6 +5,7 @@ import android.content.pm.ApplicationInfo
 import android.content.res.Configuration
 import com.mercadopago.sdk.android.checkout.core.model.CheckoutType
 import com.mercadopago.sdk.android.checkout.core.model.Order
+import com.mercadopago.sdk.android.checkout.core.model.Payer
 import com.mercadopago.sdk.android.checkout.core.model.internal.CheckoutConfiguration
 import com.mercadopago.sdk.android.checkout.data.remote.service.CardFormService
 import com.mercadopago.sdk.android.checkout.domain.usecase.GetCardBinUseCase
@@ -27,6 +28,7 @@ import org.koin.dsl.module
 import org.koin.test.check.checkModules
 import org.koin.test.mock.MockProvider
 import org.koin.test.verify.verify
+import java.math.BigDecimal
 import kotlin.test.Test
 
 internal class DataModuleTest {
@@ -61,7 +63,7 @@ internal class DataModuleTest {
         every { context.createConfigurationContext(any()) } returns context
 
         val checkoutConfiguration = CheckoutConfiguration(
-            checkoutType = CheckoutType.CardTransaction(Order()),
+            checkoutType = CheckoutType.CardTransaction(Order(amount = BigDecimal.TEN, payer = Payer(email = ""))),
             paymentMethods = emptyList(),
         )
 

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/callback/CheckoutCallbackHolderTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/callback/CheckoutCallbackHolderTest.kt
@@ -1,5 +1,6 @@
 package com.mercadopago.sdk.android.checkout.domain.callback
 
+import com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.After
@@ -9,14 +10,14 @@ import kotlin.test.assertEquals
 internal class CheckoutCallbackHolderTest {
     @After
     fun tearDown() {
-        CheckoutCallbackHolder.setCallback(null)
+        CheckoutCallbackHolder.setCallback<MPPaymentData.CardSave>(null)
         CheckoutCallbackHolder.setActivityCallback(null)
     }
 
     @Test
     fun `given callback is set then notify invokes it with the result`() {
-        val result = mockk<MercadoPagoCheckoutResult>()
-        val callback = mockk<(MercadoPagoCheckoutResult) -> Unit>(relaxed = true)
+        val result = mockk<MercadoPagoCheckoutResult<MPPaymentData.CardSave>>()
+        val callback = mockk<(MercadoPagoCheckoutResult<MPPaymentData.CardSave>) -> Unit>(relaxed = true)
         CheckoutCallbackHolder.setCallback(callback)
 
         CheckoutCallbackHolder.notify(result)
@@ -36,8 +37,8 @@ internal class CheckoutCallbackHolderTest {
 
     @Test
     fun `given both callbacks are set then notify invokes both`() {
-        val result = mockk<MercadoPagoCheckoutResult>()
-        val callback = mockk<(MercadoPagoCheckoutResult) -> Unit>(relaxed = true)
+        val result = mockk<MercadoPagoCheckoutResult<MPPaymentData.CardSave>>()
+        val callback = mockk<(MercadoPagoCheckoutResult<MPPaymentData.CardSave>) -> Unit>(relaxed = true)
         val activityCallback = mockk<() -> Unit>(relaxed = true)
         CheckoutCallbackHolder.setCallback(callback)
         CheckoutCallbackHolder.setActivityCallback(activityCallback)
@@ -51,7 +52,7 @@ internal class CheckoutCallbackHolderTest {
     @Test
     fun `given notify is called then callbacks are cleared`() {
         var invokeCount = 0
-        CheckoutCallbackHolder.setCallback { invokeCount++ }
+        CheckoutCallbackHolder.setCallback<MPPaymentData.CardSave> { invokeCount++ }
 
         CheckoutCallbackHolder.notify(mockk())
         CheckoutCallbackHolder.notify(mockk())
@@ -61,7 +62,7 @@ internal class CheckoutCallbackHolderTest {
 
     @Test
     fun `given callback is null then notify does not throw`() {
-        CheckoutCallbackHolder.setCallback(null)
+        CheckoutCallbackHolder.setCallback<MPPaymentData.CardSave>(null)
 
         CheckoutCallbackHolder.notify(mockk())
     }
@@ -75,9 +76,9 @@ internal class CheckoutCallbackHolderTest {
 
     @Test
     fun `given setCallback with null then previous callback is not invoked on notify`() {
-        val callback = mockk<(MercadoPagoCheckoutResult) -> Unit>(relaxed = true)
+        val callback = mockk<(MercadoPagoCheckoutResult<MPPaymentData.CardSave>) -> Unit>(relaxed = true)
         CheckoutCallbackHolder.setCallback(callback)
-        CheckoutCallbackHolder.setCallback(null)
+        CheckoutCallbackHolder.setCallback<MPPaymentData.CardSave>(null)
 
         CheckoutCallbackHolder.notify(mockk())
 

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModelTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModelTest.kt
@@ -662,7 +662,7 @@ internal class CardPaymentViewModelTest {
             securityCodeState = mockk<PCIFieldState>(relaxed = true),
         )
 
-        verify { CheckoutCallbackHolder.notify(match { it is MercadoPagoCheckoutResult.Success }) }
+        verify { CheckoutCallbackHolder.notify(match { it is MercadoPagoCheckoutResult.Success<*> }) }
     }
 
     @Test

--- a/example/src/main/java/com/mercadopago/sdk/android/example/presentation/checkout/CheckoutExampleScreen.kt
+++ b/example/src/main/java/com/mercadopago/sdk/android/example/presentation/checkout/CheckoutExampleScreen.kt
@@ -49,7 +49,6 @@ import com.mercadopago.sdk.android.checkout.core.model.CheckoutType
 import com.mercadopago.sdk.android.checkout.core.model.PaymentMethod
 import android.widget.Toast
 import com.mercadopago.sdk.android.checkout.domain.callback.MercadoPagoCheckoutResult
-import com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData
 import com.mercadopago.sdk.android.checkout.domain.model.UserCancelledContext
 import com.mercadopago.sdk.android.example.presentation.theme.MercadoPagoSampleTheme
 import kotlinx.coroutines.launch
@@ -106,13 +105,8 @@ internal fun CheckoutExampleScreen(
                     onRegisterCard = {
                         checkout.show { result ->
                             when (result) {
-                                is MercadoPagoCheckoutResult.Success -> {
-                                    val token = when (val data = result.paymentData) {
-                                        is MPPaymentData.CardSave -> data.token
-                                        is MPPaymentData.CardTransaction -> ""
-                                    }
-                                    state = CheckoutState.Success(token)
-                                }
+                                is MercadoPagoCheckoutResult.Success ->
+                                    state = CheckoutState.Success(result.paymentData.token)
 
                                 is MercadoPagoCheckoutResult.Error ->
                                     Toast.makeText(


### PR DESCRIPTION
# Pull Request
<!--Provide the title of the pull request-->
## Ticket or Issue link
<!--Provide link for your issue or ticket that describes this pull request-->

## Description
  MercadoPagoCheckoutResult.Success previously delivered MPPaymentData as the base sealed type. Even though the integrator already knew which CheckoutType they had configured  
  in the builder, they were forced to write a nested when on paymentData to access type-specific fields — including unreachable branches that would never execute.

  More critically, adding a new payment method (e.g. Pix) to MPPaymentData would silently break every consumer that handled Success without an else branch, with no warning or
  deprecation path.

  This PR propagates the type parameter T from CheckoutType through the builder and into the callback, so result.paymentData is already the concrete subtype at the call site —
  no cast, no nested when.

  What changed

  CheckoutType<out T : MPPaymentData> — each subtype now declares the MPPaymentData it will produce:
  - CardSave → CheckoutType<MPPaymentData.CardSave>
  - CardTransaction → CheckoutType<MPPaymentData.CardTransaction>

  MercadoPagoCheckoutResult<out T : MPPaymentData> — interface is now covariant in T:
  - Success<T> carries the concrete payment data type
  - Error and UserCancelled implement MercadoPagoCheckoutResult<Nothing> — they don't need a type parameter, and since the interface is covariant, Nothing makes them assignable
   to MercadoPagoCheckoutResult<T> for any T, preserving the exhaustive when on the consumer side

  MercadoPagoCheckout<T> / Builder<T> — T is inferred automatically from the CheckoutType passed to the constructor

  CheckoutCallbackHolder — stores callbacks with star projection internally; the single @Suppress("UNCHECKED_CAST") is safe by contract: the SDK guarantees that CardSave always
   produces MPPaymentData.CardSave

  CardPaymentViewModel — notify is now called inside each branch of the when, preserving the concrete type of Success instead of letting it be widened to the base MPPaymentData

  Integrator impact

  Before:
  ```
val checkout = MercadoPagoCheckout.Builder(context, CheckoutType.CardSave).build()

  checkout.show { result ->
      when (result) {
          is MercadoPagoCheckoutResult.Success -> {
              val token = when (val data = result.paymentData) {
                  is MPPaymentData.CardSave -> data.token
                  is MPPaymentData.CardTransaction -> ""  // unreachable
              }
          }
      }
  }
```

  After:
```
  val checkout = MercadoPagoCheckout.Builder(context, CheckoutType.CardSave).build()

  checkout.show { result ->
      when (result) {
          is MercadoPagoCheckoutResult.Success -> result.paymentData.token  // direct access
          is MercadoPagoCheckoutResult.Error -> ...
          is MercadoPagoCheckoutResult.UserCancelled -> ...
      }
  }

```

## Checklist
- [ ] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [ ] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<!---
Provide videos or screenshots. You can change their size in the src
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>
-->
