### PR TITLE
SDK-MIRROR: add PR mirroring, CI status, QA checks and UX reference protection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 **/snapshots/**/*.png filter=lfs diff=lfs merge=lfs -text
+ux-reference/deliveries/**/*.html   linguist-documentation=true

--- a/.mirrorignore
+++ b/.mirrorignore
@@ -1,0 +1,5 @@
+# .mirrorignore
+# Caminhos listados aqui são removidos de todos os pushes para o repo público.
+# O workflow lê este arquivo — nenhuma alteração no workflow é necessária para novas exclusões.
+ux-reference/
+.github/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,9 @@ repos:
             language: script
             entry: .git/hooks/pre-commit
             files: \.kt
+        -   id: ux-reference-immutability
+            name: UX Reference Immutability Check
+            description: Blocks modifications to UX deliveries already merged to main.
+            language: script
+            entry: scripts/ux_reference/check_immutability.sh
+            files: ^ux-reference/deliveries/

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,4 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.enableJetifier=true
 android.jetifier.ignorelist=android-base-common,common
+# kotlin.incremental=true

--- a/scripts/ux_reference/check_immutability.sh
+++ b/scripts/ux_reference/check_immutability.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STAGED=$(git diff --cached --name-only | grep '^ux-reference/deliveries/' || true)
+[ -z "$STAGED" ] && exit 0
+
+git fetch origin main --quiet 2>/dev/null || true
+
+BLOCKED=""
+while IFS= read -r file; do
+  if git ls-tree -r origin/main --name-only | grep -qF "$file"; then
+    BLOCKED="$BLOCKED\n  Attempted to modify: $file"
+  fi
+done <<< "$STAGED"
+
+if [ -n "$BLOCKED" ]; then
+  echo ""
+  echo "[ux-reference] BLOCKED: Modifications to existing UX deliveries are not allowed."
+  echo -e "$BLOCKED"
+  echo ""
+  echo "  UX deliveries are immutable after merge to main."
+  echo "  To update a screen, create a new dated delivery directory instead."
+  echo ""
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds bidirectional PR mirroring between private (`melisource/fury_openplatform-sdk-android`) and public (`mercadopago/sdk-android`) repos via GitHub Actions
- Adds CI status mirroring: polls CircleCI on the public repo and posts results as comments on private PRs
- Adds 4 PR quality gates as required checks: Jira ticket, 500-line size limit, 1 biz-day merge readiness, description + checklist
- Adds UX Reference delivery protection: pre-commit hook blocks modifications to deliveries already merged to main

## Checklist

- [x] `USER_PAT_MAP` and `MIRROR_TARGET_REPO` secrets set on this repo
- [x] `meliguicarvalho` already has Write access on `mercadopago/sdk-android`
- [ ] Configure required checks in branch protection: `check-jira`, `check-size`, `merge-readiness`, `check-description`
- [ ] Test run: open a test PR with a mapped user to verify mirroring (Section 7 of the guide)

## Test plan

1. Merge this PR into `main`
2. Open a new PR on this repo with user `guicarvalho_meli` — verify `mirror-pr.yml` creates a mirror branch + PR on `mercadopago/sdk-android` as `meliguicarvalho`
3. Approve the private PR — verify approval is mirrored to the public PR
4. Merge the private PR — verify public PR is merged and branch deleted
5. Wait ~5 min — verify CI status comment appears on the private PR
6. Open a PR without a Jira ticket — verify `check-jira` fails