### PR TITLE
refactor(checkout): add MP prefix to all public API types

### DIFF
--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CardTypeAnalytics.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CardTypeAnalytics.kt
@@ -1,12 +1,12 @@
 package com.mercadopago.sdk.android.checkout.analytics
 
-import com.mercadopago.sdk.android.checkout.core.model.CardType
+import com.mercadopago.sdk.android.checkout.core.model.MPCardType
 import com.mercadopago.sdk.android.core.utils.KoverIgnore
 
 @KoverIgnore("in development")
-internal fun CardType.toAnalyticsString(): String =
+internal fun MPCardType.toAnalyticsString(): String =
     when (this) {
-        CardType.CREDIT -> "credit"
-        CardType.DEBIT -> "debit"
-        CardType.PREPAID -> "prepaid"
+        MPCardType.CREDIT -> "credit"
+        MPCardType.DEBIT -> "debit"
+        MPCardType.PREPAID -> "prepaid"
     }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckout.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckout.kt
@@ -3,9 +3,9 @@ package com.mercadopago.sdk.android.checkout.core
 import android.content.Context
 import android.content.Intent
 import androidx.compose.runtime.Stable
-import com.mercadopago.sdk.android.checkout.core.model.CheckoutAppearance
-import com.mercadopago.sdk.android.checkout.core.model.CheckoutType
-import com.mercadopago.sdk.android.checkout.core.model.PaymentMethod
+import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutAppearance
+import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType
+import com.mercadopago.sdk.android.checkout.core.model.MPPaymentMethod
 import com.mercadopago.sdk.android.checkout.core.model.internal.CheckoutConfiguration
 import com.mercadopago.sdk.android.checkout.data.preferences.CheckoutThemePreferences
 import com.mercadopago.sdk.android.checkout.domain.callback.CheckoutCallbackHolder
@@ -24,7 +24,7 @@ internal const val EXTRA_CONFIGURATION = "extra_configuration"
 class MercadoPagoCheckout private constructor(
     private val context: Context,
     private val checkoutConfiguration: CheckoutConfiguration,
-    private val checkoutAppearance: CheckoutAppearance?,
+    private val checkoutAppearance: MPCheckoutAppearance?,
 ) {
     /**
      * Launches the checkout
@@ -49,25 +49,25 @@ class MercadoPagoCheckout private constructor(
     /**
      * Builder for MercadoPagoCheckout
      * @param context Context
-     * @param checkoutType CheckoutType
-     * @param checkoutAppearance CheckoutAppearance
+     * @param checkoutType MPCheckoutType
+     * @param checkoutAppearance MPCheckoutAppearance
      */
     class Builder(
         private val context: Context,
-        private val checkoutType: CheckoutType,
-        private val checkoutAppearance: CheckoutAppearance? = CheckoutAppearance(
+        private val checkoutType: MPCheckoutType,
+        private val checkoutAppearance: MPCheckoutAppearance? = MPCheckoutAppearance(
             theme = MercadoPagoThemes.Default,
             style = MercadoPagoUserInterfaceStyle.System,
         ),
     ) {
-        private var paymentMethods: List<PaymentMethod> = emptyList()
+        private var paymentMethods: List<MPPaymentMethod> = emptyList()
 
         /**
          * Sets the payment methods
          * @param paymentMethods List of payment methods
          */
         fun setPaymentMethods(
-            paymentMethods: List<PaymentMethod> = PaymentMethod.defaults,
+            paymentMethods: List<MPPaymentMethod> = MPPaymentMethod.defaults,
         ) = apply { this.paymentMethods = paymentMethods }
 
         /**

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPCardBrand.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPCardBrand.kt
@@ -9,7 +9,7 @@ import kotlinx.parcelize.Parcelize
  * This value represents the card issuer network and may affect validation rules,
  * available payment options, and card number formatting during the checkout.
  */
-sealed class CardBrand : Parcelable {
+sealed class MPCardBrand : Parcelable {
     /**
      * The name identifier of the card brand.
      */
@@ -19,7 +19,7 @@ sealed class CardBrand : Parcelable {
      * VISA: Visa card network.
      */
     @Parcelize
-    data object Visa : CardBrand() {
+    data object Visa : MPCardBrand() {
         override val name: String get() = VISA
     }
 
@@ -27,7 +27,7 @@ sealed class CardBrand : Parcelable {
      * MASTERCARD: Mastercard network.
      */
     @Parcelize
-    data object Mastercard : CardBrand() {
+    data object Mastercard : MPCardBrand() {
         override val name: String get() = MASTERCARD
     }
 
@@ -35,7 +35,7 @@ sealed class CardBrand : Parcelable {
      * AMEX: American Express card network.
      */
     @Parcelize
-    data object Amex : CardBrand() {
+    data object Amex : MPCardBrand() {
         override val name: String get() = AMEX
     }
 
@@ -43,7 +43,7 @@ sealed class CardBrand : Parcelable {
      * ELO: Elo card network (Brazil).
      */
     @Parcelize
-    data object Elo : CardBrand() {
+    data object Elo : MPCardBrand() {
         override val name: String get() = ELO
     }
 
@@ -51,7 +51,7 @@ sealed class CardBrand : Parcelable {
      * HIPERCARD: Hipercard network (Brazil).
      */
     @Parcelize
-    data object Hipercard : CardBrand() {
+    data object Hipercard : MPCardBrand() {
         override val name: String get() = HIPERCARD
     }
 
@@ -59,7 +59,7 @@ sealed class CardBrand : Parcelable {
      * DINERS: Diners Club card network.
      */
     @Parcelize
-    data object Diners : CardBrand() {
+    data object Diners : MPCardBrand() {
         override val name: String get() = DINERS
     }
 
@@ -67,7 +67,7 @@ sealed class CardBrand : Parcelable {
      * DISCOVER: Discover card network.
      */
     @Parcelize
-    data object Discover : CardBrand() {
+    data object Discover : MPCardBrand() {
         override val name: String get() = DISCOVER
     }
 
@@ -75,7 +75,7 @@ sealed class CardBrand : Parcelable {
      * JCB: Japan Credit Bureau card network.
      */
     @Parcelize
-    data object Jcb : CardBrand() {
+    data object Jcb : MPCardBrand() {
         override val name: String get() = JCB
     }
 
@@ -83,7 +83,7 @@ sealed class CardBrand : Parcelable {
      * MAESTRO: Maestro debit card network.
      */
     @Parcelize
-    data object Maestro : CardBrand() {
+    data object Maestro : MPCardBrand() {
         override val name: String get() = MAESTRO
     }
 
@@ -91,7 +91,7 @@ sealed class CardBrand : Parcelable {
      * UNIONPAY: UnionPay card network (China).
      */
     @Parcelize
-    data object UnionPay : CardBrand() {
+    data object UnionPay : MPCardBrand() {
         override val name: String get() = UNIONPAY
     }
 
@@ -99,7 +99,7 @@ sealed class CardBrand : Parcelable {
      * CABAL: Cabal card network (Argentina).
      */
     @Parcelize
-    data object Cabal : CardBrand() {
+    data object Cabal : MPCardBrand() {
         override val name: String get() = CABAL
     }
 
@@ -107,7 +107,7 @@ sealed class CardBrand : Parcelable {
      * NARANJA: Naranja card network (Argentina).
      */
     @Parcelize
-    data object Naranja : CardBrand() {
+    data object Naranja : MPCardBrand() {
         override val name: String get() = NARANJA
     }
 
@@ -118,7 +118,7 @@ sealed class CardBrand : Parcelable {
      * @param name The name identifier of the custom card brand
      */
     @Parcelize
-    data class Custom(override val name: String) : CardBrand()
+    data class Custom(override val name: String) : MPCardBrand()
 
     /**
      * Companion object containing string constants and utility values for card brands.
@@ -140,7 +140,7 @@ sealed class CardBrand : Parcelable {
         /**
          * All predefined card brands.
          */
-        val default: List<CardBrand> = listOf(
+        val default: List<MPCardBrand> = listOf(
             Visa,
             Mastercard,
             Amex,
@@ -157,7 +157,7 @@ sealed class CardBrand : Parcelable {
 
         internal fun fromString(
             value: String,
-        ): CardBrand =
+        ): MPCardBrand =
             default.find { it.name.equals(value, ignoreCase = true) }
                 ?: Custom(value)
     }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPCardType.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPCardType.kt
@@ -6,7 +6,7 @@ package com.mercadopago.sdk.android.checkout.core.model
  * This value is used to represent the selected card category and may affect
  * available payment options and UI/UX decisions during the checkout.
  */
-enum class CardType(internal val value: String) {
+enum class MPCardType(internal val value: String) {
     /**
      * CREDIT: Credit card.
      */
@@ -26,7 +26,7 @@ enum class CardType(internal val value: String) {
     internal companion object {
         internal fun fromString(
             value: String,
-        ): CardType? =
+        ): MPCardType? =
             entries.find {
                 it.value.equals(value, ignoreCase = true) ||
                     it.name.equals(value, ignoreCase = true)

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPCheckoutAppearance.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPCheckoutAppearance.kt
@@ -5,11 +5,11 @@ import com.mercadopago.sdk.android.foundation.theme.MercadoPagoThemes
 import com.mercadopago.sdk.android.foundation.theme.MercadoPagoUserInterfaceStyle
 
 /**
- * CheckoutAppearance class, used to configure the checkout appearance
+ * MPCheckoutAppearance class, used to configure the checkout appearance
  * @param theme MercadoPagoThemeConfiguration
  * @param style MercadoPagoUserInterfaceStyle
  */
-data class CheckoutAppearance(
+data class MPCheckoutAppearance(
     val theme: MercadoPagoThemeConfiguration = MercadoPagoThemes.Default,
     val style: MercadoPagoUserInterfaceStyle = MercadoPagoUserInterfaceStyle.System,
 )

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPCheckoutType.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPCheckoutType.kt
@@ -4,21 +4,21 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 /**
- * CheckoutType enum, used to configure the checkout type
+ * MPCheckoutType enum, used to configure the checkout type
  */
-sealed class CheckoutType : Parcelable {
+sealed class MPCheckoutType : Parcelable {
     /**
      * CardSave class, used to configure the card form
      */
     @Parcelize
-    object CardSave : CheckoutType()
+    object CardSave : MPCheckoutType()
 
     /**
      * CardTransaction class, used to configure the card transaction
-     * @param cardFormConfiguration Order
+     * @param cardFormConfiguration MPOrder
      */
     @Parcelize
     data class CardTransaction(
-        val cardFormConfiguration: Order = Order(),
-    ) : CheckoutType()
+        val cardFormConfiguration: MPOrder = MPOrder(),
+    ) : MPCheckoutType()
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPInstallment.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPInstallment.kt
@@ -7,12 +7,12 @@ internal const val DEFAULT_INSTALLMENT_MIN = 1
 internal const val DEFAULT_INSTALLMENT_MAX = 180
 
 /**
- * Installment class, used to configure the installments
+ * MPInstallment class, used to configure the installments
  * @param minInstallments Int
  * @param maxInstallments Int
  */
 @Parcelize
-data class Installment(
+data class MPInstallment(
     val minInstallments: Int = DEFAULT_INSTALLMENT_MIN,
     val maxInstallments: Int = DEFAULT_INSTALLMENT_MAX,
 ) : Parcelable

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPOrder.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPOrder.kt
@@ -6,12 +6,12 @@ import kotlinx.parcelize.Parcelize
 import java.math.BigDecimal
 
 /**
- * Order class, used to configure the card form
+ * MPOrder class, used to configure the card form
  * @param amount BigDecimal
- * @param payer Payer
+ * @param payer MPPayer
  */
 @Parcelize
-data class Order(
+data class MPOrder(
     val amount: BigDecimal? = null,
-    val payer: Payer? = null,
+    val payer: MPPayer? = null,
 ) : CheckoutTypeConfiguration, Parcelable

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPPayer.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPPayer.kt
@@ -4,10 +4,10 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 /**
- * Payer class, used to configure the payer
+ * MPPayer class, used to configure the payer
  * @param email String
  */
 @Parcelize
-data class Payer(
+data class MPPayer(
     val email: String,
 ) : Parcelable

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPPaymentMethod.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPPaymentMethod.kt
@@ -4,43 +4,43 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 /**
- * PaymentMethod class, used to determine the payment method
+ * MPPaymentMethod class, used to determine the payment method
  * This its used to change the payment method showed in checkout
  */
-sealed class PaymentMethod : Parcelable {
+sealed class MPPaymentMethod : Parcelable {
     /**
      * Card payment method
      * @param allowedTypes List of allowed card types
      * @param allowedBrands List of allowed card brands
-     * @param installment Installment
+     * @param installment MPInstallment
      */
     @Parcelize
     data class Card(
-        val allowedTypes: List<CardType> = listOf(CardType.CREDIT, CardType.DEBIT, CardType.PREPAID),
-        val allowedBrands: List<CardBrand> = CardBrand.default,
-        val installment: Installment? = Installment(),
-    ) : PaymentMethod()
+        val allowedTypes: List<MPCardType> = listOf(MPCardType.CREDIT, MPCardType.DEBIT, MPCardType.PREPAID),
+        val allowedBrands: List<MPCardBrand> = MPCardBrand.default,
+        val installment: MPInstallment? = MPInstallment(),
+    ) : MPPaymentMethod()
 
     /**
      * Pix payment method
      */
     @Parcelize
-    internal object Pix : PaymentMethod()
+    internal object Pix : MPPaymentMethod()
 
     /**
      * Boleto payment method
      */
     @Parcelize
-    internal object Boleto : PaymentMethod()
+    internal object Boleto : MPPaymentMethod()
 
     /**
      * Loan payment method
-     * @param installment Installment
+     * @param installment MPInstallment
      */
     @Parcelize
     data class Loan(
-        val installment: Installment,
-    ) : PaymentMethod()
+        val installment: MPInstallment,
+    ) : MPPaymentMethod()
 
     /**
      * Default payment methods
@@ -49,6 +49,6 @@ sealed class PaymentMethod : Parcelable {
         /**
          * Default payment methods
          */
-        val defaults: List<PaymentMethod> = listOf(Card(), Pix, Boleto)
+        val defaults: List<MPPaymentMethod> = listOf(Card(), Pix, Boleto)
     }
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/internal/CheckoutConfiguration.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/internal/CheckoutConfiguration.kt
@@ -1,12 +1,12 @@
 package com.mercadopago.sdk.android.checkout.core.model.internal
 
 import android.os.Parcelable
-import com.mercadopago.sdk.android.checkout.core.model.CheckoutType
-import com.mercadopago.sdk.android.checkout.core.model.PaymentMethod
+import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType
+import com.mercadopago.sdk.android.checkout.core.model.MPPaymentMethod
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class CheckoutConfiguration(
-    val checkoutType: CheckoutType,
-    val paymentMethods: List<PaymentMethod>,
+    val checkoutType: MPCheckoutType,
+    val paymentMethods: List<MPPaymentMethod>,
 ) : Parcelable

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/internal/CheckoutConfigurationExtensions.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/internal/CheckoutConfigurationExtensions.kt
@@ -1,13 +1,13 @@
 package com.mercadopago.sdk.android.checkout.core.model.internal
 
-import com.mercadopago.sdk.android.checkout.core.model.CheckoutType
+import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType
 
 internal const val CARD_TRANSACTION = "card_transaction"
 internal const val CARD_SAVE = "card_save"
 internal const val AMOUNT_DEFAULT = "0"
 
 internal fun CheckoutConfiguration.getCardFormAmount() =
-    (checkoutType as? CheckoutType.CardTransaction)
+    (checkoutType as? MPCheckoutType.CardTransaction)
         ?.cardFormConfiguration
         ?.amount
 
@@ -17,7 +17,7 @@ internal fun CheckoutConfiguration.getCardFormAmountOrZero(): String =
 
 internal fun CheckoutConfiguration?.toCheckoutType(): String =
     when (this?.checkoutType) {
-        is CheckoutType.CardSave -> CARD_SAVE
-        is CheckoutType.CardTransaction -> CARD_TRANSACTION
+        is MPCheckoutType.CardSave -> CARD_SAVE
+        is MPCheckoutType.CardTransaction -> CARD_TRANSACTION
         null -> ""
     }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/callback/MercadoPagoCheckoutResult.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/callback/MercadoPagoCheckoutResult.kt
@@ -1,8 +1,8 @@
 package com.mercadopago.sdk.android.checkout.domain.callback
 
 import com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData
+import com.mercadopago.sdk.android.checkout.domain.model.MPUserCancelledContext
 import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
-import com.mercadopago.sdk.android.checkout.domain.model.UserCancelledContext
 
 /**
  * Sealed interface representing the possible outcomes of a checkout flow.
@@ -33,5 +33,5 @@ interface MercadoPagoCheckoutResult {
      * @property context Information about the form state when cancelled, including
      * which fields were filled, empty, incomplete, or invalid
      */
-    data class UserCancelled(val context: UserCancelledContext) : MercadoPagoCheckoutResult
+    data class UserCancelled(val context: MPUserCancelledContext) : MercadoPagoCheckoutResult
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/extensions/PaymentMethodExtensions.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/extensions/PaymentMethodExtensions.kt
@@ -1,10 +1,10 @@
 package com.mercadopago.sdk.android.checkout.domain.extensions
 
-import com.mercadopago.sdk.android.checkout.core.model.CardBrand
-import com.mercadopago.sdk.android.checkout.core.model.CardType
+import com.mercadopago.sdk.android.checkout.core.model.MPCardBrand
+import com.mercadopago.sdk.android.checkout.core.model.MPCardType
 import com.mercadopago.sdk.android.checkout.domain.model.SecurityCode
 import com.mercadopago.sdk.android.coremethods.domain.model.PaymentMethod
-import com.mercadopago.sdk.android.checkout.core.model.PaymentMethod as CheckoutPaymentMethod
+import com.mercadopago.sdk.android.checkout.core.model.MPPaymentMethod as CheckoutPaymentMethod
 
 private const val DEFAULT_SECURITY_CODE_LENGTH = 3
 private const val DEFAULT_SECURITY_CODE_MODE = "mandatory"
@@ -22,7 +22,7 @@ internal fun PaymentMethod.hasIssuers() =
     this.additionalInfoNeeded?.contains(ISSUER_ID) == true &&
         this.id != null
 
-internal fun List<CheckoutPaymentMethod>?.extractCardFilters(): Pair<List<CardType>, List<CardBrand>> {
+internal fun List<CheckoutPaymentMethod>?.extractCardFilters(): Pair<List<MPCardType>, List<MPCardBrand>> {
     val cardPayment = this?.filterIsInstance<CheckoutPaymentMethod.Card>()?.firstOrNull()
     return cardPayment?.allowedTypes.orEmpty() to cardPayment?.allowedBrands.orEmpty()
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/MPCancelledFieldState.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/MPCancelledFieldState.kt
@@ -1,7 +1,7 @@
 package com.mercadopago.sdk.android.checkout.domain.model
 
-import com.mercadopago.sdk.android.checkout.core.model.CardBrand
-import com.mercadopago.sdk.android.checkout.core.model.CardType
+import com.mercadopago.sdk.android.checkout.core.model.MPCardBrand
+import com.mercadopago.sdk.android.checkout.core.model.MPCardType
 
 /**
  * Represents the state of a form field at a specific point in time.
@@ -13,7 +13,7 @@ import com.mercadopago.sdk.android.checkout.core.model.CardType
  * @property field The identifier of the form field (e.g., card number, expiration date)
  * @property state The current state of the field (e.g., valid, empty, incomplete, invalid)
  */
-data class CancelledFieldState(
+data class MPCancelledFieldState(
     val field: Field,
     val state: State,
 )
@@ -66,11 +66,11 @@ sealed class State {
      * The card brand is not accepted by the seller.
      * @property brand The card brand that is not accepted
      */
-    data class CardBrandNotAccepted(val brand: CardBrand) : State()
+    data class CardBrandNotAccepted(val brand: MPCardBrand) : State()
 
     /**
      * The card type is not accepted by the seller.
      * @property cardType The card type that is not accepted (e.g., credit card, debit card)
      */
-    data class CardTypeNotAccepted(val cardType: CardType?) : State()
+    data class CardTypeNotAccepted(val cardType: MPCardType?) : State()
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/MPCardFormUserCancelledContext.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/MPCardFormUserCancelledContext.kt
@@ -10,6 +10,6 @@ package com.mercadopago.sdk.android.checkout.domain.model
  * @property fields List of field states showing which fields were filled, empty,
  * incomplete, or invalid when the form was cancelled
  */
-data class CardFormUserCancelledContext(
-    val fields: List<CancelledFieldState>,
+data class MPCardFormUserCancelledContext(
+    val fields: List<MPCancelledFieldState>,
 )

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/MPPaymentData.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/MPPaymentData.kt
@@ -4,12 +4,12 @@ import java.math.BigDecimal
 
 /**
  * Sealed class representing the payment data resulting from a successful checkout.
- * The subtype corresponds to the [com.mercadopago.sdk.android.checkout.core.model.CheckoutType]
+ * The subtype corresponds to the [com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType]
  * configured in the builder.
  */
 sealed class MPPaymentData {
     /**
-     * Payment data for a [com.mercadopago.sdk.android.checkout.core.model.CheckoutType.CardSave] checkout.
+     * Payment data for a [com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType.CardSave] checkout.
      *
      * @property token Payment token generated for the transaction.
      * @property paymentMethodId Identifier of the selected payment method.
@@ -26,7 +26,7 @@ sealed class MPPaymentData {
     ) : MPPaymentData()
 
     /**
-     * Payment data for a [com.mercadopago.sdk.android.checkout.core.model.CheckoutType.CardTransaction] checkout.
+     * Payment data for a [com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType.CardTransaction] checkout.
      *
      * @property transactionAmount Total amount of the transaction.
      * @property paymentMethodId Identifier of the selected payment method.

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/MPUserCancelledContext.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/MPUserCancelledContext.kt
@@ -6,11 +6,11 @@ package com.mercadopago.sdk.android.checkout.domain.model
  * This sealed class provides information about which fields were filled, incomplete,
  * or invalid when the user abandoned the form without completing the payment flow.
  */
-sealed class UserCancelledContext {
+sealed class MPUserCancelledContext {
     /**
      * Represents the cancelled state of a card payment form.
      *
      * @property context Context containing the state of all card form fields when cancelled
      */
-    data class CardForm(val context: CardFormUserCancelledContext) : UserCancelledContext()
+    data class CardForm(val context: MPCardFormUserCancelledContext) : MPUserCancelledContext()
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/usecase/CardBinFilter.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/usecase/CardBinFilter.kt
@@ -1,9 +1,9 @@
 package com.mercadopago.sdk.android.checkout.domain.usecase
 
-import com.mercadopago.sdk.android.checkout.core.model.CardBrand
-import com.mercadopago.sdk.android.checkout.core.model.CardType
+import com.mercadopago.sdk.android.checkout.core.model.MPCardBrand
+import com.mercadopago.sdk.android.checkout.core.model.MPCardType
 
 internal data class CardBinFilter(
-    val cardTypes: List<CardType>,
-    val cardBrands: List<CardBrand>,
+    val cardTypes: List<MPCardType>,
+    val cardBrands: List<MPCardBrand>,
 )

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/CheckoutActivity.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/CheckoutActivity.kt
@@ -9,7 +9,7 @@ import com.mercadopago.sdk.android.checkout.analytics.metricCardFormInitialize
 import com.mercadopago.sdk.android.checkout.analytics.sellerCustomization
 import com.mercadopago.sdk.android.checkout.analytics.toAnalyticsString
 import com.mercadopago.sdk.android.checkout.core.EXTRA_CONFIGURATION
-import com.mercadopago.sdk.android.checkout.core.model.CheckoutType
+import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType
 import com.mercadopago.sdk.android.checkout.core.model.internal.CARD_SAVE
 import com.mercadopago.sdk.android.checkout.core.model.internal.CARD_TRANSACTION
 import com.mercadopago.sdk.android.checkout.core.model.internal.CheckoutConfiguration
@@ -64,8 +64,8 @@ internal class CheckoutActivity : ComponentActivity() {
     ) {
         val (cardTypes, cardBrands) = checkoutConfiguration?.paymentMethods.extractCardFilters()
         val checkoutType = when (checkoutConfiguration?.checkoutType) {
-            is CheckoutType.CardSave -> CARD_SAVE
-            is CheckoutType.CardTransaction -> CARD_TRANSACTION
+            is MPCheckoutType.CardSave -> CARD_SAVE
+            is MPCheckoutType.CardTransaction -> CARD_TRANSACTION
             null -> ""
         }
         MPAnalytics.tryGetInstance()?.trackMetric(

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/state/CardNumberErrorType.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/state/CardNumberErrorType.kt
@@ -1,7 +1,7 @@
 package com.mercadopago.sdk.android.checkout.presentation.state
 
-import com.mercadopago.sdk.android.checkout.core.model.CardBrand
-import com.mercadopago.sdk.android.checkout.core.model.CardType
+import com.mercadopago.sdk.android.checkout.core.model.MPCardBrand
+import com.mercadopago.sdk.android.checkout.core.model.MPCardType
 
 internal sealed class CardNumberErrorType {
     data class FieldValidation(val message: String) : CardNumberErrorType()
@@ -10,7 +10,7 @@ internal sealed class CardNumberErrorType {
 
     data object LuhnValidation : CardNumberErrorType()
 
-    data class CardBrandNotAccepted(val brand: CardBrand) : CardNumberErrorType()
+    data class CardBrandNotAccepted(val brand: MPCardBrand) : CardNumberErrorType()
 
-    data class CardTypeNotAccepted(val cardType: CardType?) : CardNumberErrorType()
+    data class CardTypeNotAccepted(val cardType: MPCardType?) : CardNumberErrorType()
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/usecase/CancelledFormContextUseCase.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/usecase/CancelledFormContextUseCase.kt
@@ -1,10 +1,10 @@
 package com.mercadopago.sdk.android.checkout.presentation.usecase
 
-import com.mercadopago.sdk.android.checkout.domain.model.CancelledFieldState
-import com.mercadopago.sdk.android.checkout.domain.model.CardFormUserCancelledContext
 import com.mercadopago.sdk.android.checkout.domain.model.Field
+import com.mercadopago.sdk.android.checkout.domain.model.MPCancelledFieldState
+import com.mercadopago.sdk.android.checkout.domain.model.MPCardFormUserCancelledContext
+import com.mercadopago.sdk.android.checkout.domain.model.MPUserCancelledContext
 import com.mercadopago.sdk.android.checkout.domain.model.State
-import com.mercadopago.sdk.android.checkout.domain.model.UserCancelledContext
 import com.mercadopago.sdk.android.checkout.presentation.state.CardNumberErrorType
 import com.mercadopago.sdk.android.checkout.presentation.state.CardPaymentScreenState
 import com.mercadopago.sdk.android.checkout.presentation.validation.CardHolderVerifier
@@ -15,14 +15,14 @@ import com.mercadopago.sdk.android.checkout.presentation.validation.SecurityCode
 internal class CancelledFormContextUseCase {
     operator fun invoke(
         screenState: CardPaymentScreenState,
-    ): UserCancelledContext.CardForm {
+    ): MPUserCancelledContext.CardForm {
         val fields = buildCancelledFieldStates(screenState)
-        return UserCancelledContext.CardForm(CardFormUserCancelledContext(fields))
+        return MPUserCancelledContext.CardForm(MPCardFormUserCancelledContext(fields))
     }
 
     private fun buildCancelledFieldStates(
         screenState: CardPaymentScreenState,
-    ): List<CancelledFieldState> =
+    ): List<MPCancelledFieldState> =
         buildList {
             add(buildCardNumberFieldState(screenState))
             if (screenState.cardHolderState.show) {
@@ -39,7 +39,7 @@ internal class CancelledFormContextUseCase {
 
     private fun buildCardNumberFieldState(
         screenState: CardPaymentScreenState,
-    ): CancelledFieldState {
+    ): MPCancelledFieldState {
         val cardNumberState = screenState.cardNumberState
         val state = cardNumberState.errorTypes.firstOrNull()?.let {
             when (it) {
@@ -53,12 +53,12 @@ internal class CancelledFormContextUseCase {
                 else -> State.Invalid
             }
         } ?: State.Valid
-        return CancelledFieldState(field = Field.CARD_NUMBER, state = state)
+        return MPCancelledFieldState(field = Field.CARD_NUMBER, state = state)
     }
 
     private fun buildCardHolderFieldState(
         screenState: CardPaymentScreenState,
-    ): CancelledFieldState {
+    ): MPCancelledFieldState {
         val verifier = CardHolderVerifier()
         val cardHolderState = screenState.cardHolderState
         val state = when {
@@ -67,12 +67,12 @@ internal class CancelledFormContextUseCase {
             verifier.verify(cardHolderState).isNotEmpty() -> State.Invalid
             else -> State.Valid
         }
-        return CancelledFieldState(field = Field.CARD_HOLDER, state = state)
+        return MPCancelledFieldState(field = Field.CARD_HOLDER, state = state)
     }
 
     private fun buildExpirationDateFieldState(
         screenState: CardPaymentScreenState,
-    ): CancelledFieldState {
+    ): MPCancelledFieldState {
         val verifier = ExpirationDateVerifier()
         val expirationDateState = screenState.expirationDateState
         val state = when {
@@ -81,12 +81,12 @@ internal class CancelledFormContextUseCase {
             verifier.verify(expirationDateState).isNotEmpty() -> State.Invalid
             else -> State.Valid
         }
-        return CancelledFieldState(field = Field.EXPIRATION_DATE, state = state)
+        return MPCancelledFieldState(field = Field.EXPIRATION_DATE, state = state)
     }
 
     private fun buildSecurityCodeFieldState(
         screenState: CardPaymentScreenState,
-    ): CancelledFieldState {
+    ): MPCancelledFieldState {
         val verifier = SecurityCodeVerifier()
         val secureCodeState = screenState.secureCodeState
         val state = when {
@@ -94,12 +94,12 @@ internal class CancelledFormContextUseCase {
             verifier.checkIncomplete(secureCodeState) != null -> State.Incomplete
             else -> State.Valid
         }
-        return CancelledFieldState(field = Field.SECURITY_CODE, state = state)
+        return MPCancelledFieldState(field = Field.SECURITY_CODE, state = state)
     }
 
     private fun buildDocumentFieldState(
         screenState: CardPaymentScreenState,
-    ): CancelledFieldState {
+    ): MPCancelledFieldState {
         val verifier = IdentificationTypeVerifier()
         val identificationTypeState = screenState.identificationTypeState
         val state = when {
@@ -108,6 +108,6 @@ internal class CancelledFormContextUseCase {
             verifier.verify(identificationTypeState).isNotEmpty() -> State.Invalid
             else -> State.Valid
         }
-        return CancelledFieldState(field = Field.DOCUMENT, state = state)
+        return MPCancelledFieldState(field = Field.DOCUMENT, state = state)
     }
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardFormAnalyticsTracker.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardFormAnalyticsTracker.kt
@@ -9,7 +9,7 @@ import com.mercadopago.sdk.android.checkout.analytics.metricCardFormSubmitError
 import com.mercadopago.sdk.android.checkout.analytics.metricCardFormUserCanceledError
 import com.mercadopago.sdk.android.checkout.analytics.toAnalyticsString
 import com.mercadopago.sdk.android.checkout.analytics.toErrorTypeString
-import com.mercadopago.sdk.android.checkout.core.model.CardType
+import com.mercadopago.sdk.android.checkout.core.model.MPCardType
 import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
 import com.mercadopago.sdk.android.checkout.presentation.model.CancelReason
 
@@ -55,7 +55,7 @@ internal class CardFormAnalyticsTracker(
                 cardBrand = cardBrand,
                 transactionAmount = transactionAmount,
                 issuer = issuer,
-                paymentType = CardType.fromString(paymentTypeId)?.toAnalyticsString(),
+                paymentType = MPCardType.fromString(paymentTypeId)?.toAnalyticsString(),
             ),
         )
     }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModel.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModel.kt
@@ -2,7 +2,7 @@ package com.mercadopago.sdk.android.checkout.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.mercadopago.sdk.android.checkout.core.model.CheckoutType
+import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType
 import com.mercadopago.sdk.android.checkout.core.model.internal.CheckoutConfiguration
 import com.mercadopago.sdk.android.checkout.core.model.internal.getCardFormAmount
 import com.mercadopago.sdk.android.checkout.core.model.internal.getCardFormAmountOrZero
@@ -426,14 +426,14 @@ internal class CardPaymentViewModel(
                         documentNumber = buyerIdentification.number,
                     )
                     val paymentData = when (checkoutConfiguration?.checkoutType) {
-                        is CheckoutType.CardSave -> MPPaymentData.CardSave(
+                        is MPCheckoutType.CardSave -> MPPaymentData.CardSave(
                             token = cardToken.token,
                             paymentMethodId = viewState.value.paymentState.paymentMethodId.orEmpty(),
                             paymentTypeId = viewState.value.paymentState.paymentTypeId.orEmpty(),
                             issuerId = viewState.value.cardIssuers.firstOrNull()?.id,
                             payer = payer,
                         )
-                        is CheckoutType.CardTransaction, null -> MPPaymentData.CardTransaction(
+                        is MPCheckoutType.CardTransaction, null -> MPPaymentData.CardTransaction(
                             transactionAmount = checkoutConfiguration?.getCardFormAmount(),
                             installment = 1,
                             paymentMethodId = viewState.value.paymentState.paymentMethodId.orEmpty(),

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/CardTypeAnalyticsTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/CardTypeAnalyticsTest.kt
@@ -1,22 +1,22 @@
 package com.mercadopago.sdk.android.checkout.analytics
 
-import com.mercadopago.sdk.android.checkout.core.model.CardType
+import com.mercadopago.sdk.android.checkout.core.model.MPCardType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 internal class CardTypeAnalyticsTest {
     @Test
     fun `when CardType CREDIT then toAnalyticsString returns credit`() {
-        assertEquals("credit", CardType.CREDIT.toAnalyticsString())
+        assertEquals("credit", MPCardType.CREDIT.toAnalyticsString())
     }
 
     @Test
     fun `when CardType DEBIT then toAnalyticsString returns debit`() {
-        assertEquals("debit", CardType.DEBIT.toAnalyticsString())
+        assertEquals("debit", MPCardType.DEBIT.toAnalyticsString())
     }
 
     @Test
     fun `when CardType PREPAID then toAnalyticsString returns prepaid`() {
-        assertEquals("prepaid", CardType.PREPAID.toAnalyticsString())
+        assertEquals("prepaid", MPCardType.PREPAID.toAnalyticsString())
     }
 }

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckoutTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/core/MercadoPagoCheckoutTest.kt
@@ -3,8 +3,8 @@ package com.mercadopago.sdk.android.checkout.core
 import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
-import com.mercadopago.sdk.android.checkout.core.model.CheckoutAppearance
-import com.mercadopago.sdk.android.checkout.core.model.CheckoutType
+import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutAppearance
+import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType
 import com.mercadopago.sdk.android.checkout.data.preferences.CheckoutThemePreferences
 import com.mercadopago.sdk.android.checkout.di.CheckoutModulesProvider
 import com.mercadopago.sdk.android.checkout.domain.callback.CheckoutCallbackHolder
@@ -29,7 +29,7 @@ import kotlin.test.assertSame
 
 internal class MercadoPagoCheckoutTest {
     private val context = mockk<Context>(relaxed = true)
-    private val checkoutType = CheckoutType.CardSave
+    private val checkoutType = MPCheckoutType.CardSave
     private val mockThemePreferences = mockk<CheckoutThemePreferences>(relaxed = true)
     private val mockKoin = mockk<Koin>(relaxed = true)
 
@@ -88,7 +88,7 @@ internal class MercadoPagoCheckoutTest {
     @Test
     fun `when show called with appearance then sets style from appearance`() {
         val style = MercadoPagoUserInterfaceStyle.Dark
-        val checkout = buildCheckout(appearance = CheckoutAppearance(style = style))
+        val checkout = buildCheckout(appearance = MPCheckoutAppearance(style = style))
 
         checkout.show {}
 
@@ -98,7 +98,7 @@ internal class MercadoPagoCheckoutTest {
     @Test
     fun `when show called with appearance then sets theme from appearance`() {
         val theme = MercadoPagoThemes.Default
-        val checkout = buildCheckout(appearance = CheckoutAppearance(theme = theme))
+        val checkout = buildCheckout(appearance = MPCheckoutAppearance(theme = theme))
 
         checkout.show {}
 
@@ -124,7 +124,7 @@ internal class MercadoPagoCheckoutTest {
     }
 
     private fun buildCheckout(
-        appearance: CheckoutAppearance? = CheckoutAppearance(),
+        appearance: MPCheckoutAppearance? = MPCheckoutAppearance(),
     ) = MercadoPagoCheckout.Builder(
         context = context,
         checkoutType = checkoutType,

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/CheckoutModulesProviderTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/CheckoutModulesProviderTest.kt
@@ -4,8 +4,8 @@ import android.app.Application
 import android.content.pm.ApplicationInfo
 import android.content.res.Configuration
 import com.google.gson.Gson
-import com.mercadopago.sdk.android.checkout.core.model.CheckoutType
-import com.mercadopago.sdk.android.checkout.core.model.Order
+import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType
+import com.mercadopago.sdk.android.checkout.core.model.MPOrder
 import com.mercadopago.sdk.android.checkout.core.model.internal.CheckoutConfiguration
 import com.mercadopago.sdk.android.checkout.data.preferences.CheckoutThemePreferences
 import com.mercadopago.sdk.android.checkout.domain.usecase.GetCardBinUseCase
@@ -40,7 +40,7 @@ internal class CheckoutModulesProviderTest {
         mockkObject(MercadoPagoSDK.Companion)
         mockkStatic(ApplicationInfo::class)
         mockkObject(CoreKoinFactory)
-        mockkObject(CheckoutType::class)
+        mockkObject(MPCheckoutType::class)
         mockkObject(CardPaymentScreenStateFactory::class)
         mockkConstructor(Configuration::class)
     }
@@ -69,7 +69,7 @@ internal class CheckoutModulesProviderTest {
         )
 
         val checkoutConfiguration = CheckoutConfiguration(
-            checkoutType = CheckoutType.CardTransaction(Order()),
+            checkoutType = MPCheckoutType.CardTransaction(MPOrder()),
             paymentMethods = emptyList(),
         )
         val module = module {
@@ -85,7 +85,7 @@ internal class CheckoutModulesProviderTest {
         module.verify(
             extraTypes = listOf(
                 CoreMethods::class,
-                CheckoutType::class,
+                MPCheckoutType::class,
                 List::class,
                 CheckoutConfiguration::class,
                 CheckoutThemePreferences::class,

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/DataModuleTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/DataModuleTest.kt
@@ -3,8 +3,8 @@ package com.mercadopago.sdk.android.checkout.di
 import android.app.Application
 import android.content.pm.ApplicationInfo
 import android.content.res.Configuration
-import com.mercadopago.sdk.android.checkout.core.model.CheckoutType
-import com.mercadopago.sdk.android.checkout.core.model.Order
+import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType
+import com.mercadopago.sdk.android.checkout.core.model.MPOrder
 import com.mercadopago.sdk.android.checkout.core.model.internal.CheckoutConfiguration
 import com.mercadopago.sdk.android.checkout.data.remote.service.CardFormService
 import com.mercadopago.sdk.android.checkout.domain.usecase.GetCardBinUseCase
@@ -61,7 +61,7 @@ internal class DataModuleTest {
         every { context.createConfigurationContext(any()) } returns context
 
         val checkoutConfiguration = CheckoutConfiguration(
-            checkoutType = CheckoutType.CardTransaction(Order()),
+            checkoutType = MPCheckoutType.CardTransaction(MPOrder()),
             paymentMethods = emptyList(),
         )
 
@@ -79,7 +79,7 @@ internal class DataModuleTest {
         module.verify(
             extraTypes = listOf(
                 CheckoutConfiguration::class,
-                CheckoutType::class,
+                MPCheckoutType::class,
                 List::class,
                 CardFormService::class,
                 GetCardBinUseCase::class,

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/extensions/PaymentMethodExtensionsTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/extensions/PaymentMethodExtensionsTest.kt
@@ -1,7 +1,7 @@
 package com.mercadopago.sdk.android.checkout.domain.extensions
 
-import com.mercadopago.sdk.android.checkout.core.model.CardBrand
-import com.mercadopago.sdk.android.checkout.core.model.CardType
+import com.mercadopago.sdk.android.checkout.core.model.MPCardBrand
+import com.mercadopago.sdk.android.checkout.core.model.MPCardType
 import com.mercadopago.sdk.android.coremethods.domain.model.CardModel
 import com.mercadopago.sdk.android.coremethods.domain.model.PaymentMethod
 import com.mercadopago.sdk.android.coremethods.domain.model.SecurityCodeModel
@@ -9,7 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import com.mercadopago.sdk.android.checkout.core.model.PaymentMethod as CheckoutPaymentMethod
+import com.mercadopago.sdk.android.checkout.core.model.MPPaymentMethod as CheckoutPaymentMethod
 
 internal class PaymentMethodExtensionsTest {
     @Test
@@ -93,8 +93,8 @@ internal class PaymentMethodExtensionsTest {
 
     @Test
     fun `given list with Card type then extractCardFilters returns its filters`() {
-        val allowedTypes = listOf(CardType.CREDIT)
-        val allowedBrands = listOf(CardBrand.Visa)
+        val allowedTypes = listOf(MPCardType.CREDIT)
+        val allowedBrands = listOf(MPCardBrand.Visa)
         val paymentMethods = listOf(
             CheckoutPaymentMethod.Card(allowedTypes = allowedTypes, allowedBrands = allowedBrands),
         )

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/usecase/CancelledFormContextUseCaseTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/usecase/CancelledFormContextUseCaseTest.kt
@@ -1,11 +1,11 @@
 package com.mercadopago.sdk.android.checkout.presentation.usecase
 
-import com.mercadopago.sdk.android.checkout.core.model.CardBrand
-import com.mercadopago.sdk.android.checkout.core.model.CardType
-import com.mercadopago.sdk.android.checkout.domain.model.CancelledFieldState
+import com.mercadopago.sdk.android.checkout.core.model.MPCardBrand
+import com.mercadopago.sdk.android.checkout.core.model.MPCardType
 import com.mercadopago.sdk.android.checkout.domain.model.Field
+import com.mercadopago.sdk.android.checkout.domain.model.MPCancelledFieldState
+import com.mercadopago.sdk.android.checkout.domain.model.MPUserCancelledContext
 import com.mercadopago.sdk.android.checkout.domain.model.State
-import com.mercadopago.sdk.android.checkout.domain.model.UserCancelledContext
 import com.mercadopago.sdk.android.checkout.presentation.state.CardHolderState
 import com.mercadopago.sdk.android.checkout.presentation.state.CardNumberErrorType
 import com.mercadopago.sdk.android.checkout.presentation.state.CardNumberState
@@ -37,9 +37,9 @@ internal class CancelledFormContextUseCaseTest {
 
     private fun invoke(
         state: CardPaymentScreenState,
-    ): List<CancelledFieldState> {
+    ): List<MPCancelledFieldState> {
         val result = useCase(state)
-        assertIs<UserCancelledContext.CardForm>(result)
+        assertIs<MPUserCancelledContext.CardForm>(result)
         return result.context.fields
     }
 
@@ -92,26 +92,26 @@ internal class CancelledFormContextUseCaseTest {
 
     @Test
     fun `given card number has CardBrandNotAccepted error then state is CardBrandNotAccepted`() {
-        val errorType = CardNumberErrorType.CardBrandNotAccepted(CardBrand.Visa)
+        val errorType = CardNumberErrorType.CardBrandNotAccepted(MPCardBrand.Visa)
         val state = makeState(cardNumberState = CardNumberState(errorTypes = listOf(errorType)))
 
         val fields = invoke(state)
 
         val cardNumberField = fields.first { it.field == Field.CARD_NUMBER }
         assertIs<State.CardBrandNotAccepted>(cardNumberField.state)
-        assertEquals(CardBrand.Visa, cardNumberField.state.brand)
+        assertEquals(MPCardBrand.Visa, cardNumberField.state.brand)
     }
 
     @Test
     fun `given card number has CardTypeNotAccepted error then state is CardTypeNotAccepted`() {
-        val errorType = CardNumberErrorType.CardTypeNotAccepted(CardType.CREDIT)
+        val errorType = CardNumberErrorType.CardTypeNotAccepted(MPCardType.CREDIT)
         val state = makeState(cardNumberState = CardNumberState(errorTypes = listOf(errorType)))
 
         val fields = invoke(state)
 
         val cardNumberField = fields.first { it.field == Field.CARD_NUMBER }
         assertIs<State.CardTypeNotAccepted>(cardNumberField.state)
-        assertEquals(CardType.CREDIT, cardNumberField.state.cardType)
+        assertEquals(MPCardType.CREDIT, cardNumberField.state.cardType)
     }
 
     @Test
@@ -321,7 +321,7 @@ internal class CancelledFormContextUseCaseTest {
     fun `given default state then result contains cardNumber and expirationDate fields`() {
         val result = useCase(makeState())
 
-        assertIs<UserCancelledContext.CardForm>(result)
+        assertIs<MPUserCancelledContext.CardForm>(result)
         val fields = result.context.fields
         assertEquals(true, fields.any { it.field == Field.CARD_NUMBER })
         assertEquals(true, fields.any { it.field == Field.EXPIRATION_DATE })

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModelTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModelTest.kt
@@ -2,10 +2,10 @@ package com.mercadopago.sdk.android.checkout.presentation.viewmodel
 
 import com.mercadopago.sdk.android.analytics.domain.interactor.MPAnalytics
 import com.mercadopago.sdk.android.analytics.domain.models.Metric
-import com.mercadopago.sdk.android.checkout.core.model.CardBrand
-import com.mercadopago.sdk.android.checkout.core.model.CardType
-import com.mercadopago.sdk.android.checkout.core.model.CheckoutType
-import com.mercadopago.sdk.android.checkout.core.model.PaymentMethod
+import com.mercadopago.sdk.android.checkout.core.model.MPCardBrand
+import com.mercadopago.sdk.android.checkout.core.model.MPCardType
+import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType
+import com.mercadopago.sdk.android.checkout.core.model.MPPaymentMethod
 import com.mercadopago.sdk.android.checkout.core.model.internal.CheckoutConfiguration
 import com.mercadopago.sdk.android.checkout.data.remote.response.CardNumberConfig
 import com.mercadopago.sdk.android.checkout.data.remote.response.DocumentTranslations
@@ -71,11 +71,11 @@ internal class CardPaymentViewModelTest {
     private val cardPaymentScreenStateFactory = mockk<CardPaymentScreenStateFactory>(relaxed = true)
 
     private val checkoutConfiguration = CheckoutConfiguration(
-        checkoutType = mockk<CheckoutType.CardTransaction>(relaxed = true),
+        checkoutType = mockk<MPCheckoutType.CardTransaction>(relaxed = true),
         paymentMethods = listOf(
-            PaymentMethod.Card(
-                allowedTypes = listOf(CardType.CREDIT, CardType.DEBIT),
-                allowedBrands = listOf(CardBrand.Visa, CardBrand.Mastercard),
+            MPPaymentMethod.Card(
+                allowedTypes = listOf(MPCardType.CREDIT, MPCardType.DEBIT),
+                allowedBrands = listOf(MPCardBrand.Visa, MPCardBrand.Mastercard),
             ),
         ),
     )

--- a/example/src/main/java/com/mercadopago/sdk/android/example/presentation/checkout/CheckoutExampleScreen.kt
+++ b/example/src/main/java/com/mercadopago/sdk/android/example/presentation/checkout/CheckoutExampleScreen.kt
@@ -45,12 +45,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.mercadopago.sdk.android.checkout.core.MercadoPagoCheckout
-import com.mercadopago.sdk.android.checkout.core.model.CheckoutType
-import com.mercadopago.sdk.android.checkout.core.model.PaymentMethod
+import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType
+import com.mercadopago.sdk.android.checkout.core.model.MPPaymentMethod
 import android.widget.Toast
 import com.mercadopago.sdk.android.checkout.domain.callback.MercadoPagoCheckoutResult
 import com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData
-import com.mercadopago.sdk.android.checkout.domain.model.UserCancelledContext
+import com.mercadopago.sdk.android.checkout.domain.model.MPUserCancelledContext
 import com.mercadopago.sdk.android.example.presentation.theme.MercadoPagoSampleTheme
 import kotlinx.coroutines.launch
 
@@ -69,8 +69,8 @@ internal fun CheckoutExampleScreen(
     val checkout = remember {
         MercadoPagoCheckout.Builder(
             context = context,
-            checkoutType = CheckoutType.CardSave,
-        ).setPaymentMethods(listOf(PaymentMethod.Card()))
+            checkoutType = MPCheckoutType.CardSave,
+        ).setPaymentMethods(listOf(MPPaymentMethod.Card()))
             .build()
     }
 
@@ -123,7 +123,7 @@ internal fun CheckoutExampleScreen(
 
                                 is MercadoPagoCheckoutResult.UserCancelled -> {
                                     val fieldsInfo = when (val ctx = result.context) {
-                                        is UserCancelledContext.CardForm ->
+                                        is MPUserCancelledContext.CardForm ->
                                             ctx.context.fields.joinToString(", ") { field ->
                                                 "${field.field.name}: ${field.state::class.simpleName}"
                                             }


### PR DESCRIPTION


# Pull Request
<!--Provide the title of the pull request-->
## Ticket or Issue link
<!--Provide link for your issue or ticket that describes this pull request-->

## Description
Renames 11 public types to add the `MP` prefix, aligning Android with the iOS SDK (PR #198). No logic changes — purely a rename.

Types renamed:
- CardBrand            → MPCardBrand
- CardType             → MPCardType
- Installment          → MPInstallment
- Order                → MPOrder
- Payer                → MPPayer
- PaymentMethod        → MPPaymentMethod
- CheckoutAppearance   → MPCheckoutAppearance
- CheckoutType         → MPCheckoutType
- UserCancelledContext         → MPUserCancelledContext
- CardFormUserCancelledContext → MPCardFormUserCancelledContext
- CancelledFieldState          → MPCancelledFieldState

All internal references, tests, and example app updated accordingly. Internal types (CheckoutConfiguration, CheckoutTypeConfiguration) and already-prefixed types (MPPaymentData, MercadoPagoCheckoutError) are unchanged.
## Checklist
- [ ] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Verify that you are merged with the latest in develop.
- [ ] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<!---
Provide videos or screenshots. You can change their size in the src
<p float="center">
    <img width="200" src="">
    <img width="200" src="">
</p>
-->
