### PR TITLE
feat(flowbook): add Flowbook UX handoff tool

### DIFF
--- a/.mirrorignore
+++ b/.mirrorignore
@@ -2,4 +2,5 @@
 # Caminhos listados aqui são removidos de todos os pushes para o repo público.
 # O workflow lê este arquivo — nenhuma alteração no workflow é necessária para novas exclusões.
 ux-reference/
+Flowbook/
 .github/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
         -   id: end-of-file-fixer
         -   id: check-yaml
         -   id: check-added-large-files
+            exclude: ^Flowbook/
   -   repo: local
       hooks:
         -   id: pre-commit


### PR DESCRIPTION
## O que é

O **Flowbook** é uma ferramenta de UX handoff interativa para o time de design. Permite visualizar e navegar pelas telas do Bricks Nativos com configurações contextuais por site, dispositivo e estado — sem precisar rodar o app.

## Como rodar

Basta abrir o arquivo diretamente no navegador — não precisa de servidor, build, nem dependências:

```bash
open Flowbook/flowbook-bricks-nativos.html
```

Ou arraste o arquivo `Flowbook/flowbook-bricks-nativos.html` para qualquer navegador moderno.

### Funcionalidades

- **Pantalla** — navega tela a tela (Payment, Card Form, Tarjeta Guardada, Installments...)  
- **Flujo completo** — simula a navegação completa entre telas com os botões do celular  
- **Site** — alterna entre MLA, MLB, MLM, MLU, MCO, MPE, MLC  
- **Dispositivo** — alterna entre iOS e Android (muda o frame do celular)  
- **Configuração adicional** — toggles para Mercado Pago, línea de crédito, tarjeta guardada, Pix, Boleto, Efectivo, Nueva tarjeta  
- **No se permite** — restrições por tela (⊘)

## Screenshots

**iOS — Payment Brick (MLA)**
![Flowbook iOS Payment](https://raw.githubusercontent.com/melisource/fury_openplatform-sdk-android/feature/ux-handoff/Flowbook/screenshots/flowbook-ios-payment.png)

**Android — Payment Brick (MLA)**
![Flowbook Android Payment](https://raw.githubusercontent.com/melisource/fury_openplatform-sdk-android/feature/ux-handoff/Flowbook/screenshots/flowbook-android-payment.png)

## Mudanças

- `Flowbook/` — ferramenta de handoff UX (HTML interativo + assets)  
- `.mirrorignore` — `Flowbook/` adicionado para nunca vazar para o repo público  
- `.pre-commit-config.yaml` — exclusão do `check-added-large-files` para `Flowbook/` (HTML auto-contido intencional)