### PR TITLE
fix(review): replace isLoading guard with AtomicBoolean in onInstallmentConfirmed

### DIFF
--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CardFormInitAnalytics.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CardFormInitAnalytics.kt
@@ -6,12 +6,14 @@ import com.mercadopago.sdk.android.analytics.domain.models.EventData
 import com.mercadopago.sdk.android.analytics.domain.models.Metric
 import com.mercadopago.sdk.android.analytics.domain.models.TrackType
 import com.mercadopago.sdk.android.checkout.analytics.CheckoutAnalyticsConstants.CHECKOUT_CARD_FORM_PATH
+import com.mercadopago.sdk.android.checkout.analytics.CheckoutAnalyticsConstants.NOT_APPLY
 import com.mercadopago.sdk.android.core.utils.KoverIgnore
 import com.mercadopago.sdk.android.initializer.analytics.SDK_NATIVE_PATH
 
 private const val INITIALIZE_PATH = "/initialize"
 private const val INITIALIZE_ERROR_PATH = "/initialize_error"
 
+@Suppress("LongParameterList")
 @KoverIgnore("in development")
 internal fun metricCardFormInitialize(
     checkoutType: String,
@@ -19,6 +21,7 @@ internal fun metricCardFormInitialize(
     sellerCustomization: List<String>,
     excludedPaymentTypes: List<String>,
     excludedPaymentMethods: List<String>,
+    orderId: String,
 ) = Metric(
     path = "$SDK_NATIVE_PATH$CHECKOUT_CARD_FORM_PATH$INITIALIZE_PATH",
     type = TrackType.EVENT,
@@ -28,6 +31,7 @@ internal fun metricCardFormInitialize(
         sellerCustomization = sellerCustomization,
         excludedPaymentTypes = excludedPaymentTypes,
         excludedPaymentMethods = excludedPaymentMethods,
+        orderId = orderId.ifEmpty { NOT_APPLY },
     ),
 )
 
@@ -52,4 +56,6 @@ internal data class CardFormInitEventData(
     val excludedPaymentTypes: List<String>,
     @SerializedName("excluded_payment_methods")
     val excludedPaymentMethods: List<String>,
+    @SerializedName("order_id")
+    val orderId: String,
 ) : EventData

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CheckoutAnalyticsConstants.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CheckoutAnalyticsConstants.kt
@@ -3,4 +3,6 @@ package com.mercadopago.sdk.android.checkout.analytics
 internal object CheckoutAnalyticsConstants {
     internal const val CHECKOUT_CARD_FORM_PATH = "/checkout/card_form"
     internal const val CHECKOUT_INSTALLMENTS_PATH = "/checkout/installments"
+    internal const val ORDER_PATH = "/order"
+    internal const val NOT_APPLY = "NOT_APPLY"
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/InstallmentsInitializeAnalytics.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/InstallmentsInitializeAnalytics.kt
@@ -34,6 +34,8 @@ internal data class InstallmentsInitializeEventData(
     val quotasCount: Int,
     @SerializedName("transaction_amount")
     val transactionAmount: Double,
+    @SerializedName("order_id")
+    val orderId: String,
 ) : EventData
 
 internal fun InstallmentsDisplayType.toAnalyticsString(): String =

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/OrderErrorAnalytics.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/OrderErrorAnalytics.kt
@@ -1,0 +1,29 @@
+package com.mercadopago.sdk.android.checkout.analytics
+
+import com.google.gson.annotations.SerializedName
+import com.mercadopago.sdk.android.analytics.domain.models.EventData
+import com.mercadopago.sdk.android.analytics.domain.models.Metric
+import com.mercadopago.sdk.android.analytics.domain.models.TrackType
+import com.mercadopago.sdk.android.checkout.analytics.CheckoutAnalyticsConstants.ORDER_PATH
+import com.mercadopago.sdk.android.initializer.analytics.SDK_NATIVE_PATH
+
+private const val ERROR_PATH = "/error"
+
+internal fun metricOrderError(
+    errorType: String,
+    orderId: String,
+) = Metric(
+    path = "$SDK_NATIVE_PATH$ORDER_PATH$ERROR_PATH",
+    type = TrackType.EVENT,
+    data = OrderErrorEventData(
+        errorType = errorType,
+        orderId = orderId,
+    ),
+)
+
+internal data class OrderErrorEventData(
+    @SerializedName("error_type")
+    val errorType: String,
+    @SerializedName("order_id")
+    val orderId: String,
+) : EventData

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/OrderSubmitAnalytics.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/OrderSubmitAnalytics.kt
@@ -1,0 +1,29 @@
+package com.mercadopago.sdk.android.checkout.analytics
+
+import com.google.gson.annotations.SerializedName
+import com.mercadopago.sdk.android.analytics.domain.models.EventData
+import com.mercadopago.sdk.android.analytics.domain.models.Metric
+import com.mercadopago.sdk.android.analytics.domain.models.TrackType
+import com.mercadopago.sdk.android.checkout.analytics.CheckoutAnalyticsConstants.ORDER_PATH
+import com.mercadopago.sdk.android.initializer.analytics.SDK_NATIVE_PATH
+
+private const val SUBMIT_PATH = "/submit"
+
+internal fun metricOrderSubmit(
+    orderId: String,
+    orderStatus: String,
+) = Metric(
+    path = "$SDK_NATIVE_PATH$ORDER_PATH$SUBMIT_PATH",
+    type = TrackType.EVENT,
+    data = OrderSubmitEventData(
+        orderId = orderId,
+        orderStatus = orderStatus,
+    ),
+)
+
+internal data class OrderSubmitEventData(
+    @SerializedName("order_id")
+    val orderId: String,
+    @SerializedName("order_status")
+    val orderStatus: String,
+) : EventData

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPOrder.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/MPOrder.kt
@@ -7,11 +7,13 @@ import java.math.BigDecimal
 
 /**
  * MPOrder class, used to configure the card form
+ * @param orderId orderId
  * @param amount BigDecimal
  * @param payer MPPayer
  */
 @Parcelize
 data class MPOrder(
+    val orderId: String,
     val amount: BigDecimal,
     val payer: MPPayer,
 ) : CheckoutTypeConfiguration, Parcelable

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/internal/CheckoutConfigurationExtensions.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/core/model/internal/CheckoutConfigurationExtensions.kt
@@ -28,7 +28,12 @@ internal fun CheckoutConfiguration?.toCheckoutType(): String =
         null -> ""
     }
 
-internal fun CheckoutConfiguration?.showsInstallments(): Boolean = this?.checkoutType is MPCheckoutType.CardTransaction
+internal fun CheckoutConfiguration?.getOrderId(): String = this.asCardTransaction()?.order?.orderId.orEmpty()
+
+internal fun CheckoutConfiguration?.asCardTransaction(): MPCheckoutType.CardTransaction? =
+    this?.checkoutType as? MPCheckoutType.CardTransaction
+
+internal fun CheckoutConfiguration?.isCardTransaction(): Boolean = this?.checkoutType is MPCheckoutType.CardTransaction
 
 internal fun CheckoutConfiguration?.startsWithPayment(): Boolean {
     return this?.checkoutType is MPCheckoutType.Payment

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/remote/datasource/OrderRemoteDataSource.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/remote/datasource/OrderRemoteDataSource.kt
@@ -1,0 +1,12 @@
+package com.mercadopago.sdk.android.checkout.data.remote.datasource
+
+import com.mercadopago.sdk.android.checkout.data.remote.response.OrderProcessResponse
+import com.mercadopago.sdk.android.checkout.domain.model.ResponseError
+import com.mercadopago.sdk.android.checkout.domain.model.params.ProcessOrderParams
+import com.mercadopago.sdk.android.coremethods.domain.utils.Result
+
+internal interface OrderRemoteDataSource {
+    suspend fun process(
+        params: ProcessOrderParams,
+    ): Result<OrderProcessResponse, ResponseError>
+}

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/remote/datasource/OrderRemoteDataSourceImpl.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/remote/datasource/OrderRemoteDataSourceImpl.kt
@@ -1,0 +1,27 @@
+package com.mercadopago.sdk.android.checkout.data.remote.datasource
+
+import com.mercadopago.sdk.android.checkout.data.remote.mapper.toInternalResponse
+import com.mercadopago.sdk.android.checkout.data.remote.request.OrderProcessRequest
+import com.mercadopago.sdk.android.checkout.data.remote.response.OrderProcessResponse
+import com.mercadopago.sdk.android.checkout.data.remote.service.OrderService
+import com.mercadopago.sdk.android.checkout.domain.model.ResponseError
+import com.mercadopago.sdk.android.checkout.domain.model.params.ProcessOrderParams
+import com.mercadopago.sdk.android.coremethods.domain.utils.Result
+
+internal class OrderRemoteDataSourceImpl(
+    private val service: OrderService,
+) : OrderRemoteDataSource {
+    override suspend fun process(
+        params: ProcessOrderParams,
+    ): Result<OrderProcessResponse, ResponseError> =
+        service.process(
+            orderId = params.orderId,
+            body = OrderProcessRequest(
+                amount = params.amount,
+                paymentMethodId = params.paymentMethodId,
+                paymentMethodType = params.paymentMethodType,
+                token = params.token,
+                installments = params.installments,
+            ),
+        ).toInternalResponse()
+}

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/remote/mapper/OrderProcessResponseMapper.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/remote/mapper/OrderProcessResponseMapper.kt
@@ -1,0 +1,10 @@
+package com.mercadopago.sdk.android.checkout.data.remote.mapper
+
+import com.mercadopago.sdk.android.checkout.data.remote.response.OrderProcessResponse
+import com.mercadopago.sdk.android.checkout.domain.model.OrderProcessOutput
+
+internal fun OrderProcessResponse.toDomain(): OrderProcessOutput =
+    OrderProcessOutput(
+        id = id.orEmpty(),
+        status = status.orEmpty(),
+    )

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/remote/request/OrderProcessRequest.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/remote/request/OrderProcessRequest.kt
@@ -1,0 +1,9 @@
+package com.mercadopago.sdk.android.checkout.data.remote.request
+
+internal data class OrderProcessRequest(
+    val amount: String,
+    val paymentMethodId: String,
+    val paymentMethodType: String,
+    val token: String,
+    val installments: Int,
+)

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/remote/response/OrderProcessResponse.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/remote/response/OrderProcessResponse.kt
@@ -1,0 +1,171 @@
+package com.mercadopago.sdk.android.checkout.data.remote.response
+
+internal data class OrderProcessResponse(
+    val id: String?,
+    val productId: String?,
+    val processingMode: String?,
+    val externalReference: String?,
+    val description: String?,
+    val totalAmount: String?,
+    val totalPaidAmount: String?,
+    val expirationTime: String?,
+    val checkoutAvailableAt: String?,
+    val siteId: String?,
+    val userId: String?,
+    val createdDate: String?,
+    val lastUpdatedDate: String?,
+    val type: String?,
+    val status: String?,
+    val statusDetail: String?,
+    val captureMode: String?,
+    val currency: String?,
+    val config: OrderConfigResponse?,
+    val integrationData: OrderIntegrationDataResponse?,
+    val payer: OrderPayerResponse?,
+    val shipment: OrderShipmentResponse?,
+    val transactions: OrderTransactionsResponse?,
+    val items: List<OrderItemResponse>?,
+)
+
+internal data class OrderConfigResponse(
+    val online: OrderOnlineConfigResponse?,
+)
+
+internal data class OrderOnlineConfigResponse(
+    val transactionSecurity: OrderTransactionSecurityConfigResponse?,
+)
+
+internal data class OrderTransactionSecurityConfigResponse(
+    val validation: String?,
+    val liabilityShift: String?,
+)
+
+internal data class OrderIntegrationDataResponse(
+    val applicationId: String?,
+    val product: String?,
+    val integratorId: String?,
+    val platformId: String?,
+    val sponsor: OrderSponsorResponse?,
+)
+
+internal data class OrderSponsorResponse(
+    val id: String?,
+)
+
+internal data class OrderPayerResponse(
+    val entityType: String?,
+    val email: String?,
+    val firstName: String?,
+    val lastName: String?,
+    val identification: OrderIdentificationResponse?,
+    val phone: OrderPhoneResponse?,
+)
+
+internal data class OrderIdentificationResponse(
+    val type: String?,
+    val number: String?,
+)
+
+internal data class OrderPhoneResponse(
+    val areaCode: String?,
+    val number: String?,
+)
+
+internal data class OrderShipmentResponse(
+    val address: OrderAddressResponse?,
+)
+
+internal data class OrderAddressResponse(
+    val streetName: String?,
+    val streetNumber: String?,
+    val neighborhood: String?,
+    val city: String?,
+    val state: String?,
+    val zipCode: String?,
+)
+
+internal data class OrderTransactionsResponse(
+    val payments: List<OrderPaymentResponse>?,
+    val refunds: List<OrderRefundResponse>?,
+)
+
+internal data class OrderPaymentResponse(
+    val id: String?,
+    val referenceId: String?,
+    val amount: String?,
+    val status: String?,
+    val statusDetail: String?,
+    val paidAmount: String?,
+    val tipAmount: String?,
+    val confirmedAmount: String?,
+    val installmentAmount: String?,
+    val source: String?,
+    val provider: String?,
+    val expirationTime: String?,
+    val dateOfExpiration: String?,
+    val paymentMethod: OrderPaymentMethodResponse?,
+    val card: OrderCardResponse?,
+    val reference: OrderReferenceResponse?,
+)
+
+internal data class OrderPaymentMethodResponse(
+    val id: String?,
+    val type: String?,
+    val token: String?,
+    val statementDescriptor: String?,
+    val installments: Int?,
+    val e2eId: String?,
+    val redirectUrl: String?,
+    val barcodeContent: String?,
+    val ticketUrl: String?,
+    val transactionSecurity: OrderPaymentTransactionSecurityResponse?,
+)
+
+internal data class OrderPaymentTransactionSecurityResponse(
+    val id: String?,
+    val url: String?,
+    val type: String?,
+    val status: String?,
+    val validation: String?,
+    val liabilityShift: String?,
+)
+
+internal data class OrderCardResponse(
+    val firstDigits: String?,
+    val lastDigits: String?,
+)
+
+internal data class OrderReferenceResponse(
+    val id: String?,
+    val source: String?,
+    val metadata: OrderReferenceMetadataResponse?,
+)
+
+internal data class OrderReferenceMetadataResponse(
+    val fromId: String?,
+    val to: List<OrderReferenceTargetResponse>?,
+)
+
+internal data class OrderReferenceTargetResponse(
+    val id: String?,
+    val userId: String?,
+)
+
+internal data class OrderRefundResponse(
+    val id: String?,
+)
+
+internal data class OrderItemResponse(
+    val title: String?,
+    val description: String?,
+    val unitPrice: String?,
+    val externalCode: String?,
+    val categoryId: String?,
+    val type: String?,
+    val pictureUrl: String?,
+    val quantity: Int?,
+    val warranty: Boolean?,
+    val eventDate: String?,
+    val unitMeasure: String?,
+    val externalPosition: String?,
+)

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/remote/service/OrderService.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/remote/service/OrderService.kt
@@ -1,0 +1,19 @@
+package com.mercadopago.sdk.android.checkout.data.remote.service
+
+import com.mercadopago.sdk.android.checkout.data.remote.request.OrderProcessRequest
+import com.mercadopago.sdk.android.checkout.data.remote.response.OrderProcessResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+private const val BRICKS_API = "cho-off"
+private const val VERSION = "v1"
+
+internal interface OrderService {
+    @POST("$BRICKS_API/$VERSION/orders/{order_id}/process")
+    suspend fun process(
+        @Path("order_id") orderId: String,
+        @Body body: OrderProcessRequest,
+    ): Response<OrderProcessResponse>
+}

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/repository/OrderRepositoryImpl.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/data/repository/OrderRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.mercadopago.sdk.android.checkout.data.repository
+
+import com.mercadopago.sdk.android.checkout.data.remote.datasource.OrderRemoteDataSource
+import com.mercadopago.sdk.android.checkout.data.remote.mapper.toDomain
+import com.mercadopago.sdk.android.checkout.domain.extensions.map
+import com.mercadopago.sdk.android.checkout.domain.extensions.withErrorHandling
+import com.mercadopago.sdk.android.checkout.domain.model.OrderProcessOutput
+import com.mercadopago.sdk.android.checkout.domain.model.ResponseError
+import com.mercadopago.sdk.android.checkout.domain.model.params.ProcessOrderParams
+import com.mercadopago.sdk.android.checkout.domain.repository.OrderRepository
+import com.mercadopago.sdk.android.coremethods.domain.utils.Result
+
+internal class OrderRepositoryImpl(
+    private val dataSource: OrderRemoteDataSource,
+) : OrderRepository {
+    override suspend fun process(
+        params: ProcessOrderParams,
+    ): Result<OrderProcessOutput, ResponseError> =
+        withErrorHandling {
+            dataSource.process(params = params)
+        }.map { it.toDomain() }
+}

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/di/DataModule.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/di/DataModule.kt
@@ -6,13 +6,18 @@ import com.mercadopago.sdk.android.checkout.data.preferences.CheckoutThemePrefer
 import com.mercadopago.sdk.android.checkout.data.provider.AndroidStringProvider
 import com.mercadopago.sdk.android.checkout.data.remote.datasource.CardFormRemoteDataSource
 import com.mercadopago.sdk.android.checkout.data.remote.datasource.CardFormRemoteDataSourceImpl
+import com.mercadopago.sdk.android.checkout.data.remote.datasource.OrderRemoteDataSource
+import com.mercadopago.sdk.android.checkout.data.remote.datasource.OrderRemoteDataSourceImpl
 import com.mercadopago.sdk.android.checkout.data.repository.CardFormRepositoryImpl
+import com.mercadopago.sdk.android.checkout.data.repository.OrderRepositoryImpl
 import com.mercadopago.sdk.android.checkout.domain.model.MPInstallmentData
 import com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData
 import com.mercadopago.sdk.android.checkout.domain.provider.StringProvider
 import com.mercadopago.sdk.android.checkout.domain.repository.CardFormRepository
+import com.mercadopago.sdk.android.checkout.domain.repository.OrderRepository
 import com.mercadopago.sdk.android.checkout.domain.usecase.GetCardBinUseCase
 import com.mercadopago.sdk.android.checkout.domain.usecase.InitializeCardFormUseCase
+import com.mercadopago.sdk.android.checkout.domain.usecase.ProcessOrderUseCase
 import com.mercadopago.sdk.android.checkout.presentation.factory.CardPaymentScreenStateFactory
 import com.mercadopago.sdk.android.checkout.presentation.usecase.GenerateTokenUseCase
 import com.mercadopago.sdk.android.checkout.presentation.viewmodel.CardPaymentViewModel
@@ -42,6 +47,12 @@ internal fun provideDataModule() =
         factory {
             InitializeCardFormUseCase(repository = get())
         }
+        factory<OrderRemoteDataSource> {
+            OrderRemoteDataSourceImpl(service = get())
+        }
+        factory<OrderRepository> {
+            OrderRepositoryImpl(dataSource = get())
+        }
         factory {
             CardPaymentScreenStateFactory(stringProvider = get())
         }
@@ -51,14 +62,21 @@ internal fun provideDataModule() =
                 getCardBinUseCase = GetCardBinUseCase(repository = get()),
                 initializeCardFormUseCase = get(),
                 generateTokenUseCase = GenerateTokenUseCase(),
+                processOrderUseCase = ProcessOrderUseCase(repository = get()),
                 cardPaymentScreenStateFactory = get(),
             )
         }
-        viewModel { (installmentData: MPInstallmentData, paymentData: MPPaymentData, checkoutType: String) ->
+        viewModel { params ->
+            val (
+                installmentData: MPInstallmentData,
+                paymentData: MPPaymentData,
+                checkoutType: String,
+            ) = params
             InstallmentsViewModel(
                 installmentData = installmentData,
                 paymentData = paymentData,
                 checkoutType = checkoutType,
+                orderId = (params.component4() as? String).orEmpty(),
             )
         }
         viewModel { PaymentBrickViewModel() }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/di/NetworkModule.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.mercadopago.sdk.android.checkout.di
 
 import com.mercadopago.sdk.android.checkout.data.remote.service.CardFormService
+import com.mercadopago.sdk.android.checkout.data.remote.service.OrderService
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
@@ -11,5 +12,8 @@ internal fun provideNetworkModule(
         single { RetrofitFactory(baseUrl) }
         single {
             get<RetrofitFactory>().createService(CardFormService::class.java)
+        }
+        single {
+            get<RetrofitFactory>().createService(OrderService::class.java)
         }
     }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/exception/ErrorLocalized.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/exception/ErrorLocalized.kt
@@ -4,4 +4,5 @@ internal enum class ErrorLocalized {
     TOKENIZATION,
     CARD_FORM_INITIALIZATION,
     CARD_BIN,
+    ORDER_PROCESS,
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/MPPaymentData.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/MPPaymentData.kt
@@ -28,6 +28,8 @@ sealed class MPPaymentData {
     /**
      * Payment data for a [com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType.CardTransaction] checkout.
      *
+     * @property orderId Identifier of the order associated with the transaction.
+     * @property orderStatus Current status of the order.
      * @property transactionAmount Total amount of the transaction.
      * @property paymentMethodId Identifier of the selected payment method.
      * @property paymentTypeId Identifier of the selected payment type.
@@ -36,6 +38,8 @@ sealed class MPPaymentData {
      * @property issuerId Optional identifier of the card issuer.
      */
     data class CardTransaction(
+        val orderId: String,
+        val orderStatus: String,
         val transactionAmount: BigDecimal?,
         val paymentMethodId: String,
         val paymentTypeId: String,
@@ -45,8 +49,10 @@ sealed class MPPaymentData {
     ) : MPPaymentData()
 
     /**
-     * Payment data for a [com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType.CardTransaction] checkout.
+     * Payment data for a [com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType.Payment] checkout.
      *
+     * @property orderId Identifier of the processed order.
+     * @property orderStatus Status of the processed order.
      * @property transactionAmount Total amount of the transaction.
      * @property paymentMethodId Identifier of the selected payment method.
      * @property paymentTypeId Identifier of the selected payment type.
@@ -55,6 +61,8 @@ sealed class MPPaymentData {
      * @property issuerId Optional identifier of the card issuer.
      */
     data class Payment(
+        val orderId: String,
+        val orderStatus: String,
         val transactionAmount: BigDecimal?,
         val paymentMethodId: String,
         val paymentTypeId: String,

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/OrderProcessOutput.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/OrderProcessOutput.kt
@@ -1,0 +1,6 @@
+package com.mercadopago.sdk.android.checkout.domain.model
+
+internal data class OrderProcessOutput(
+    val id: String,
+    val status: String,
+)

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/params/ProcessOrderParams.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/params/ProcessOrderParams.kt
@@ -1,0 +1,10 @@
+package com.mercadopago.sdk.android.checkout.domain.model.params
+
+internal data class ProcessOrderParams(
+    val orderId: String,
+    val amount: String,
+    val paymentMethodId: String,
+    val paymentMethodType: String,
+    val token: String,
+    val installments: Int,
+)

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/repository/OrderRepository.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/repository/OrderRepository.kt
@@ -1,0 +1,12 @@
+package com.mercadopago.sdk.android.checkout.domain.repository
+
+import com.mercadopago.sdk.android.checkout.domain.model.OrderProcessOutput
+import com.mercadopago.sdk.android.checkout.domain.model.ResponseError
+import com.mercadopago.sdk.android.checkout.domain.model.params.ProcessOrderParams
+import com.mercadopago.sdk.android.coremethods.domain.utils.Result
+
+internal interface OrderRepository {
+    suspend fun process(
+        params: ProcessOrderParams,
+    ): Result<OrderProcessOutput, ResponseError>
+}

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/usecase/ProcessOrderUseCase.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/usecase/ProcessOrderUseCase.kt
@@ -1,0 +1,21 @@
+package com.mercadopago.sdk.android.checkout.domain.usecase
+
+import com.mercadopago.sdk.android.checkout.domain.exception.ErrorLocalized
+import com.mercadopago.sdk.android.checkout.domain.exception.ExceptionFactory.mapError
+import com.mercadopago.sdk.android.checkout.domain.extensions.withErrorHandling
+import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.OrderProcessOutput
+import com.mercadopago.sdk.android.checkout.domain.model.params.ProcessOrderParams
+import com.mercadopago.sdk.android.checkout.domain.repository.OrderRepository
+import com.mercadopago.sdk.android.coremethods.domain.utils.Result
+
+internal class ProcessOrderUseCase(
+    private val repository: OrderRepository,
+) {
+    suspend operator fun invoke(
+        params: ProcessOrderParams,
+    ): Result<OrderProcessOutput, MercadoPagoCheckoutError> =
+        withErrorHandling {
+            repository.process(params = params)
+        }.mapError(ErrorLocalized.ORDER_PROCESS)
+}

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/CheckoutActivity.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/CheckoutActivity.kt
@@ -14,6 +14,7 @@ import com.mercadopago.sdk.android.checkout.core.model.internal.CARD_SAVE
 import com.mercadopago.sdk.android.checkout.core.model.internal.CARD_TRANSACTION
 import com.mercadopago.sdk.android.checkout.core.model.internal.CheckoutConfiguration
 import com.mercadopago.sdk.android.checkout.core.model.internal.PAYMENT
+import com.mercadopago.sdk.android.checkout.core.model.internal.getOrderId
 import com.mercadopago.sdk.android.checkout.data.preferences.CheckoutThemePreferences
 import com.mercadopago.sdk.android.checkout.domain.callback.CheckoutCallbackHolder
 import com.mercadopago.sdk.android.checkout.domain.extensions.extractCardFilters
@@ -76,6 +77,7 @@ internal class CheckoutActivity : ComponentActivity() {
                 sellerCustomization = checkoutThemePreferences.getCurrentThemeScheme().sellerCustomization,
                 excludedPaymentTypes = excludedTypes.map { it.toAnalyticsString() },
                 excludedPaymentMethods = excludedMethods.map { it.name },
+                orderId = checkoutConfiguration?.getOrderId().orEmpty(),
             ),
         )
     }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/CheckoutController.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/CheckoutController.kt
@@ -14,7 +14,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.mercadopago.sdk.android.checkout.core.model.internal.CheckoutConfiguration
-import com.mercadopago.sdk.android.checkout.core.model.internal.showsInstallments
+import com.mercadopago.sdk.android.checkout.core.model.internal.getOrderId
 import com.mercadopago.sdk.android.checkout.core.model.internal.startsWithPayment
 import com.mercadopago.sdk.android.checkout.core.model.internal.toCheckoutType
 import com.mercadopago.sdk.android.checkout.domain.callback.CheckoutCallbackHolder
@@ -36,6 +36,7 @@ import com.mercadopago.sdk.android.checkout.presentation.viewmodel.PaymentBrickV
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 
+@Suppress("LongMethod")
 @Composable
 internal fun CheckoutController(
     checkoutConfiguration: CheckoutConfiguration?,
@@ -74,8 +75,12 @@ internal fun CheckoutController(
         }
 
         composable<CheckoutDestination.Form> {
+            val graphEntry = remember { navController.getBackStackEntry<CheckoutGraph>() }
+            val cardPaymentViewModel: CardPaymentViewModel = koinViewModel(
+                viewModelStoreOwner = graphEntry,
+            ) { parametersOf(checkoutConfiguration) }
             CardFormScreenDestination(
-                checkoutConfiguration = checkoutConfiguration,
+                cardPaymentViewModel = cardPaymentViewModel,
                 onNavigateToInstallments = { installmentData, paymentData ->
                     pendingInstallmentData = installmentData
                     pendingPaymentData = paymentData
@@ -87,10 +92,21 @@ internal fun CheckoutController(
         composable<CheckoutDestination.Installment> {
             val installmentData = pendingInstallmentData ?: return@composable
             val paymentData = pendingPaymentData ?: return@composable
+            val graphEntry = remember { navController.getBackStackEntry<CheckoutGraph>() }
+            val cardPaymentViewModel: CardPaymentViewModel = koinViewModel(
+                viewModelStoreOwner = graphEntry,
+            ) { parametersOf(checkoutConfiguration) }
+            val cardPaymentViewState by cardPaymentViewModel.viewState.collectAsState()
+
             InstallmentsScreenDestination(
                 installmentData = installmentData,
                 paymentData = paymentData,
                 checkoutType = checkoutConfiguration.toCheckoutType(),
+                orderId = checkoutConfiguration?.getOrderId().orEmpty(),
+                onInstallmentConfirmed = { installments ->
+                    cardPaymentViewModel.onInstallmentConfirmed(installments)
+                },
+                isLoading = cardPaymentViewState.isLoading,
                 onBackClick = { navController.popBackStack() },
             )
         }
@@ -120,39 +136,43 @@ private fun PaymentBrickScreenDestination(
 
 @Composable
 private fun CardFormScreenDestination(
-    checkoutConfiguration: CheckoutConfiguration?,
+    cardPaymentViewModel: CardPaymentViewModel,
     onNavigateToInstallments: (MPInstallmentData, MPPaymentData) -> Unit,
 ) {
-    val cardPaymentViewModel: CardPaymentViewModel = koinViewModel {
-        parametersOf(checkoutConfiguration)
-    }
     val viewEvent by cardPaymentViewModel.viewEvent.collectAsState()
 
     LaunchedEffect(viewEvent) {
         when (val event = viewEvent) {
             is CardPaymentViewEvent.OnSuccess -> {
-                if (checkoutConfiguration.showsInstallments()) {
-                    cardPaymentViewModel.markScreenPresented(Screen.INSTALLMENTS)
-                    onNavigateToInstallments(event.installment, event.payment)
-                } else {
-                    CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.Success(event.payment))
-                }
                 cardPaymentViewModel.onViewEventConsumed()
+                when {
+                    event.payment is MPPaymentData.CardTransaction &&
+                        event.installment.quotas.size == 1 ->
+                        cardPaymentViewModel.onInstallmentConfirmed(
+                            event.installment.quotas.first().installments ?: 1,
+                        )
+                    event.installment.quotas.isNotEmpty() -> {
+                        cardPaymentViewModel.markScreenPresented(Screen.INSTALLMENTS)
+                        onNavigateToInstallments(event.installment, event.payment)
+                    }
+                    else ->
+                        CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.Success(event.payment))
+                }
             }
 
             is CardPaymentViewEvent.OnFailure -> {
-                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.Error(event.error))
                 cardPaymentViewModel.onViewEventConsumed()
+                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.Error(event.error))
             }
 
             is CardPaymentViewEvent.OnUserCancelled -> {
-                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.UserCancelled(event.context))
                 cardPaymentViewModel.onViewEventConsumed()
+                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.UserCancelled(event.context))
             }
 
             is CardPaymentViewEvent.OnBackPressed -> {
-                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.UserCancelled(event.context))
                 cardPaymentViewModel.onViewEventConsumed()
+                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.UserCancelled(event.context))
             }
 
             null -> Unit
@@ -162,38 +182,43 @@ private fun CardFormScreenDestination(
     CardPaymentScreen(viewModel = cardPaymentViewModel)
 }
 
+@Suppress("LongParameterList")
 @Composable
 private fun InstallmentsScreenDestination(
     installmentData: MPInstallmentData,
     paymentData: MPPaymentData,
     checkoutType: String,
+    orderId: String,
+    onInstallmentConfirmed: (Int) -> Unit,
+    isLoading: Boolean,
     onBackClick: () -> Unit,
 ) {
     val installmentsViewModel: InstallmentsViewModel = koinViewModel {
-        parametersOf(installmentData, paymentData, checkoutType)
+        parametersOf(installmentData, paymentData, checkoutType, orderId)
     }
     val viewEvent by installmentsViewModel.viewEvent.collectAsState()
 
     LaunchedEffect(viewEvent) {
         when (val event = viewEvent) {
             is InstallmentViewEvent.OnSuccess -> {
-                val updated = when (paymentData) {
-                    is MPPaymentData.CardTransaction -> paymentData.copy(installment = event.installment)
-                    is MPPaymentData.CardSave -> paymentData
-                    is MPPaymentData.Payment -> paymentData
-                }
-                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.Success(updated))
                 installmentsViewModel.onViewEventConsumed()
+                when (paymentData) {
+                    is MPPaymentData.CardTransaction -> onInstallmentConfirmed(event.installment)
+                    is MPPaymentData.CardSave -> {
+                        CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.Success(paymentData))
+                    }
+                    is MPPaymentData.Payment -> onInstallmentConfirmed(event.installment)
+                }
             }
 
             is InstallmentViewEvent.OnFailure -> {
-                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.Error(event.error))
                 installmentsViewModel.onViewEventConsumed()
+                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.Error(event.error))
             }
 
             is InstallmentViewEvent.OnUserCancelled -> {
-                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.UserCancelled(event.context))
                 installmentsViewModel.onViewEventConsumed()
+                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.UserCancelled(event.context))
             }
 
             null -> Unit
@@ -202,6 +227,7 @@ private fun InstallmentsScreenDestination(
 
     InstallmentsScreen(
         viewModel = installmentsViewModel,
+        isLoading = isLoading,
         onBackClick = {
             installmentsViewModel.onBackPressed()
             onBackClick()

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/cardpayment/CardPaymentScreenContent.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/cardpayment/CardPaymentScreenContent.kt
@@ -86,7 +86,9 @@ internal fun CardPaymentScreen(
     }
 
     BackHandler {
-        viewModel.onBackPressed(CancelReason.SystemBack)
+        if (!viewState.isLoading) {
+            viewModel.onBackPressed(CancelReason.SystemBack)
+        }
     }
 
     CardPaymentScreenContent(
@@ -101,7 +103,7 @@ internal fun CardPaymentScreen(
         onSecurityCodeEvent = viewModel::onSecurityCodeEvent,
         onCardHolderEvent = viewModel::onCardHolderEvent,
         onIdentificationEvent = viewModel::onIdentificationEvent,
-        onBackPressed = { viewModel.onBackPressed(CancelReason.UiButton) },
+        onBackPressed = { if (!viewState.isLoading) viewModel.onBackPressed(CancelReason.UiButton) },
         onTooltipClick = viewModel::onTooltipClick,
         onMessageClick = viewModel::onMessageClick,
         onFooterButtonClick = {
@@ -566,6 +568,7 @@ private fun CardPaymentFormFields(
     }
 }
 
+@Suppress("UnusedPrivateMember")
 @Composable
 private fun CardPaymentFooter(
     footerState: FooterState,
@@ -589,6 +592,7 @@ private fun CardPaymentFooter(
     }
 }
 
+@Suppress("UnusedPrivateMember")
 @Composable
 private fun CardPaymentFooterButtonOverlay(
     buttonLabel: String,

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/installments/InstallmentsScreen.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/installments/InstallmentsScreen.kt
@@ -1,5 +1,7 @@
 package com.mercadopago.sdk.android.checkout.presentation.installments
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
@@ -36,6 +39,7 @@ import com.mercadopago.sdk.android.components.MPFixedFooter
 import com.mercadopago.sdk.android.components.MPFixedFooterButtonData
 import com.mercadopago.sdk.android.components.MPHeader
 import com.mercadopago.sdk.android.components.MPListItem
+import com.mercadopago.sdk.android.components.MPProgressIndicator
 import com.mercadopago.sdk.android.components.model.MPListItemContentInfo
 import com.mercadopago.sdk.android.components.model.MPListItemTrailing
 import com.mercadopago.sdk.android.components.model.MPListItemType
@@ -45,21 +49,27 @@ import com.mercadopago.sdk.android.foundation.theme.MercadoPagoThemes
 @Composable
 internal fun InstallmentsScreen(
     viewModel: InstallmentsViewModel,
+    isLoading: Boolean = false,
     onBackClick: () -> Unit = {},
 ) {
     val viewState by viewModel.viewState.collectAsState()
 
+    BackHandler(enabled = isLoading) { }
+
     InstallmentsScreenContent(
         viewState = viewState,
+        isLoading = isLoading,
         onBackClick = onBackClick,
         onItemClick = viewModel::onInstallmentSelected,
         onPayClick = viewModel::onPayClicked,
     )
 }
 
+@Suppress("LongMethod")
 @Composable
 private fun InstallmentsScreenContent(
     viewState: InstallmentsScreenState,
+    isLoading: Boolean = false,
     onBackClick: () -> Unit = {},
     onItemClick: (Int) -> Unit = {},
     onPayClick: () -> Unit = {},
@@ -108,6 +118,17 @@ private fun InstallmentsScreenContent(
                     .align(Alignment.BottomCenter)
                     .onGloballyPositioned { footerHeightPx = it.size.height },
             )
+        }
+
+        if (isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.White),
+                contentAlignment = Alignment.Center,
+            ) {
+                MPProgressIndicator()
+            }
         }
     }
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/usecase/CancelledFormContextUseCase.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/usecase/CancelledFormContextUseCase.kt
@@ -52,7 +52,9 @@ internal class CancelledFormContextUseCase {
                     cardNumberState.length < cardNumberState.maxLength -> State.Incomplete
                     else -> State.Invalid
                 }
-                else -> State.Invalid
+                is CardNumberErrorType.PaymentMethodNotFound,
+                is CardNumberErrorType.LuhnValidation,
+                -> State.Invalid
             }
         } ?: State.Valid
         return MPCancelledFieldState(field = Field.CARD_NUMBER, state = state)

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardFormAnalyticsTracker.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardFormAnalyticsTracker.kt
@@ -7,6 +7,8 @@ import com.mercadopago.sdk.android.checkout.analytics.metricCardFormInputValidat
 import com.mercadopago.sdk.android.checkout.analytics.metricCardFormSubmit
 import com.mercadopago.sdk.android.checkout.analytics.metricCardFormSubmitError
 import com.mercadopago.sdk.android.checkout.analytics.metricCardFormUserCanceledError
+import com.mercadopago.sdk.android.checkout.analytics.metricOrderError
+import com.mercadopago.sdk.android.checkout.analytics.metricOrderSubmit
 import com.mercadopago.sdk.android.checkout.analytics.toAnalyticsString
 import com.mercadopago.sdk.android.checkout.analytics.toErrorTypeString
 import com.mercadopago.sdk.android.checkout.core.model.MPCardType
@@ -61,11 +63,35 @@ internal class CardFormAnalyticsTracker(
         )
     }
 
+    fun trackOrderSubmit(
+        orderId: String,
+        orderStatus: String,
+    ) {
+        MPAnalytics.tryGetInstance()?.trackMetric(
+            metricOrderSubmit(
+                orderId = orderId,
+                orderStatus = orderStatus,
+            ),
+        )
+    }
+
     fun trackSubmitError(
         error: MercadoPagoCheckoutError,
     ) {
         MPAnalytics.tryGetInstance()?.trackMetric(
             metricCardFormSubmitError(errorType = error.toErrorTypeString()),
+        )
+    }
+
+    fun trackOrderError(
+        error: MercadoPagoCheckoutError,
+        orderId: String,
+    ) {
+        MPAnalytics.tryGetInstance()?.trackMetric(
+            metricOrderError(
+                errorType = error.toErrorTypeString(),
+                orderId = orderId,
+            ),
         )
     }
 

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModel.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModel.kt
@@ -6,9 +6,13 @@ import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType
 import com.mercadopago.sdk.android.checkout.core.model.internal.CheckoutConfiguration
 import com.mercadopago.sdk.android.checkout.core.model.internal.getCardFormAmount
 import com.mercadopago.sdk.android.checkout.core.model.internal.getCardFormAmountOrZero
+import com.mercadopago.sdk.android.checkout.core.model.internal.getOrderId
+import com.mercadopago.sdk.android.checkout.core.model.internal.isCardTransaction
 import com.mercadopago.sdk.android.checkout.core.model.internal.toCheckoutType
 import com.mercadopago.sdk.android.checkout.core.model.internal.unsupportedTypeError
 import com.mercadopago.sdk.android.checkout.data.remote.utils.PROCESSING_MODE
+import com.mercadopago.sdk.android.checkout.domain.callback.CheckoutCallbackHolder
+import com.mercadopago.sdk.android.checkout.domain.callback.MercadoPagoCheckoutResult
 import com.mercadopago.sdk.android.checkout.domain.exception.ErrorLocalized
 import com.mercadopago.sdk.android.checkout.domain.extensions.extractCardFilters
 import com.mercadopago.sdk.android.checkout.domain.extensions.isComplete
@@ -50,6 +54,7 @@ internal class CardPaymentViewModel(
     private val initializeCardFormUseCase: InitializeCardFormUseCase,
     private val getCardBinUseCase: GetCardBinUseCase,
     private val generateTokenUseCase: GenerateTokenUseCase,
+    private val processOrderUseCase: ProcessOrderUseCase,
     private val cardPaymentScreenStateFactory: CardPaymentScreenStateFactory,
 ) : ViewModel() {
     private val _viewState = MutableStateFlow(CardPaymentScreenState())
@@ -59,6 +64,8 @@ internal class CardPaymentViewModel(
     val viewEvent: StateFlow<CardPaymentViewEvent?> = _viewEvent.asStateFlow()
 
     private val cancelledFormContextUseCase = CancelledFormContextUseCase()
+
+    private var pendingOrderData: PendingOrderData? = null
 
     private val analyticsTracker = CardFormAnalyticsTracker(
         isLoading = { _viewState.value.isLoading },
@@ -480,15 +487,106 @@ internal class CardPaymentViewModel(
         }
     }
 
+    private fun handleToken(
+        token: String,
+        payer: Payer,
+    ) {
+        if (checkoutConfiguration.isCardTransaction()) {
+            pendingOrderData = PendingOrderData(token = token, payer = payer)
+        }
+        analyticsTracker.trackSubmit(
+            cardBrand = viewState.value.paymentState.paymentMethodId.orEmpty(),
+            transactionAmount = checkoutConfiguration?.getCardFormAmount()?.toDouble() ?: 0.0,
+            issuer = viewState.value.cardIssuers.firstOrNull()?.id.orEmpty(),
+            paymentTypeId = viewState.value.paymentState.paymentTypeId.orEmpty(),
+        )
+        val paymentData = buildPaymentData(token = token, payer = payer)
+        if (paymentData != null) {
+            val state = _viewState.value
+            _viewEvent.value = CardPaymentViewEvent.OnSuccess(
+                payment = paymentData,
+                installment = MPInstallmentData(
+                    quotas = state.installmentsState.installments,
+                    display = MPInstallmentData.InstallmentDisplay(
+                        title = state.installmentsState.title,
+                        currencySymbol = state.currencySymbol,
+                        displayType = state.installmentsState.displayType,
+                        footer = MPInstallmentData.InstallmentFooterDisplay(
+                            footerTitle = state.installmentsState.totalLabel,
+                            lastFourDigits = state.cardNumberState.lastFourDigits,
+                            brand = state.paymentState.paymentMethodId.orEmpty(),
+                            buttonLabel = state.installmentsState.buttonLabel,
+                        ),
+                    ),
+                ),
+            )
+        } else {
+            _viewEvent.value = CardPaymentViewEvent.OnFailure(
+                checkoutConfiguration?.checkoutType.unsupportedTypeError(
+                    localized = ErrorLocalized.TOKENIZATION,
+                ),
+            )
+        }
+    }
+
+    @Suppress("UnusedPrivateMember")
+    private suspend fun processOrder(
+        installments: Int,
+    ) {
+        val orderId = checkoutConfiguration.getOrderId()
+        val token = pendingOrderData?.token.orEmpty()
+        val payer = pendingOrderData?.payer ?: Payer()
+        processOrderUseCase(
+            ProcessOrderParams(
+                orderId = orderId,
+                amount = checkoutConfiguration?.getCardFormAmountOrZero().orEmpty(),
+                paymentMethodId = viewState.value.paymentState.paymentMethodId.orEmpty(),
+                paymentMethodType = viewState.value.paymentState.paymentTypeId.orEmpty(),
+                token = token,
+                installments = installments,
+            ),
+        ).fold(
+            onSuccess = { orderOutput ->
+                analyticsTracker.trackOrderSubmit(
+                    orderId = orderOutput.id,
+                    orderStatus = orderOutput.status,
+                )
+                val paymentData = buildPaymentData(
+                    token = token,
+                    payer = payer,
+                    orderOutput = orderOutput,
+                    installments = installments,
+                )
+                if (paymentData != null) {
+                    CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.Success(paymentData))
+                } else {
+                    CheckoutCallbackHolder.notify(
+                        MercadoPagoCheckoutResult.Error(
+                            checkoutConfiguration?.checkoutType.unsupportedTypeError(
+                                localized = ErrorLocalized.TOKENIZATION,
+                            ),
+                        ),
+                    )
+                }
+                _viewState.value = _viewState.value.copy(isLoading = false)
+                pendingOrderData = null
+            },
+            onError = { error ->
+                analyticsTracker.trackOrderError(error = error, orderId = orderId)
+                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.Error(error))
+                _viewState.value = _viewState.value.copy(isLoading = false)
+                pendingOrderData = null
+            },
+        )
+    }
+
     private fun buildPaymentData(
         token: String,
-        buyerIdentification: BuyerIdentification,
-    ): MPPaymentData? {
-        val payer = Payer(
-            documentType = buyerIdentification.type,
-            documentNumber = buyerIdentification.number,
-        )
-        return when (checkoutConfiguration?.checkoutType) {
+        payer: Payer,
+        orderOutput: OrderProcessOutput? = null,
+        installments: Int = 1,
+    ): MPPaymentData? =
+        when (checkoutConfiguration?.checkoutType) {
             is MPCheckoutType.CardSave -> MPPaymentData.CardSave(
                 token = token,
                 paymentMethodId = viewState.value.paymentState.paymentMethodId.orEmpty(),
@@ -500,8 +598,10 @@ internal class CardPaymentViewModel(
             is MPCheckoutType.CardTransaction,
             is MPCheckoutType.Payment,
             -> MPPaymentData.CardTransaction(
+                orderId = orderOutput?.id.orEmpty(),
+                orderStatus = orderOutput?.status.orEmpty(),
                 transactionAmount = checkoutConfiguration.getCardFormAmount(),
-                installment = 1,
+                installment = installments,
                 paymentMethodId = viewState.value.paymentState.paymentMethodId.orEmpty(),
                 paymentTypeId = viewState.value.paymentState.paymentTypeId.orEmpty(),
                 issuerId = viewState.value.cardIssuers.firstOrNull()?.id,
@@ -510,5 +610,4 @@ internal class CardPaymentViewModel(
 
             else -> null
         }
-    }
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/InstallmentsAnalyticsTracker.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/InstallmentsAnalyticsTracker.kt
@@ -16,6 +16,7 @@ internal class InstallmentsAnalyticsTracker(
     private val checkoutType: String,
     private val paymentData: MPPaymentData,
     private val installmentData: MPInstallmentData,
+    private val orderId: String,
 ) {
     private var terminated = false
 
@@ -30,6 +31,7 @@ internal class InstallmentsAnalyticsTracker(
                     selectionType = installmentData.display.displayType.toAnalyticsString(),
                     quotasCount = installmentData.quotas.size,
                     transactionAmount = transaction?.transactionAmount?.toDouble() ?: 0.0,
+                    orderId = orderId,
                 ),
             ),
         )

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/InstallmentsViewModel.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/InstallmentsViewModel.kt
@@ -23,10 +23,12 @@ internal class InstallmentsViewModel(
     private val installmentData: MPInstallmentData,
     private val paymentData: MPPaymentData,
     checkoutType: String,
+    orderId: String,
     private val analyticsTracker: InstallmentsAnalyticsTracker = InstallmentsAnalyticsTracker(
         checkoutType = checkoutType,
         paymentData = paymentData,
         installmentData = installmentData,
+        orderId = orderId,
     ),
 ) : ViewModel() {
     private val initialSelection = installmentData.selectedInstallment

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/PendingOrderData.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/PendingOrderData.kt
@@ -1,0 +1,8 @@
+package com.mercadopago.sdk.android.checkout.presentation.viewmodel
+
+import com.mercadopago.sdk.android.checkout.domain.model.Payer
+
+internal data class PendingOrderData(
+    val token: String,
+    val payer: Payer,
+)

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/CardFormInitAnalyticsTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/CardFormInitAnalyticsTest.kt
@@ -15,6 +15,7 @@ internal class CardFormInitAnalyticsTest {
             sellerCustomization = listOf("customized_token"),
             excludedPaymentTypes = listOf("credit", "debit"),
             excludedPaymentMethods = listOf("visa", "master"),
+            orderId = "123",
         )
 
         assertEquals("/checkout_api_native/checkout/card_form/initialize", metric.path)
@@ -29,6 +30,7 @@ internal class CardFormInitAnalyticsTest {
             sellerCustomization = emptyList(),
             excludedPaymentTypes = listOf("credit"),
             excludedPaymentMethods = listOf("visa"),
+            orderId = "order-abc",
         )
 
         val data = assertIs<CardFormInitEventData>(metric.data)
@@ -37,6 +39,22 @@ internal class CardFormInitAnalyticsTest {
         assertEquals(emptyList(), data.sellerCustomization)
         assertEquals(listOf("credit"), data.excludedPaymentTypes)
         assertEquals(listOf("visa"), data.excludedPaymentMethods)
+        assertEquals("order-abc", data.orderId)
+    }
+
+    @Test
+    fun `when metricCardFormInitialize called with empty orderId then orderId resolves to NOT_APPLY`() {
+        val metric = metricCardFormInitialize(
+            checkoutType = "card_form",
+            appearance = "light",
+            sellerCustomization = emptyList(),
+            excludedPaymentTypes = emptyList(),
+            excludedPaymentMethods = emptyList(),
+            orderId = "",
+        )
+
+        val data = assertIs<CardFormInitEventData>(metric.data)
+        assertEquals("NOT_APPLY", data.orderId)
     }
 
     @Test

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/InstallmentsInitializeAnalyticsTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/InstallmentsInitializeAnalyticsTest.kt
@@ -21,6 +21,7 @@ internal class InstallmentsInitializeAnalyticsTest {
         selectionType = selectionType,
         quotasCount = quotasCount,
         transactionAmount = transactionAmount,
+        orderId = "",
     )
 
     @Test

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/core/model/MPCardBrandTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/core/model/MPCardBrandTest.kt
@@ -3,7 +3,6 @@ package com.mercadopago.sdk.android.checkout.core.model
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
-import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 internal class MPCardBrandTest {
@@ -53,14 +52,14 @@ internal class MPCardBrandTest {
 
     @Test
     fun `given fromString with known name then returns matching predefined brand`() {
-        assertSame(MPCardBrand.Visa, MPCardBrand.fromString("visa"))
-        assertSame(MPCardBrand.Mastercard, MPCardBrand.fromString("master"))
+        assertEquals(MPCardBrand.Visa, MPCardBrand.fromString("visa"))
+        assertEquals(MPCardBrand.Mastercard, MPCardBrand.fromString("master"))
     }
 
     @Test
     fun `given fromString with known name in different case then returns matching brand`() {
-        assertSame(MPCardBrand.Amex, MPCardBrand.fromString("AMEX"))
-        assertSame(MPCardBrand.Elo, MPCardBrand.fromString("Elo"))
+        assertEquals(MPCardBrand.Amex, MPCardBrand.fromString("AMEX"))
+        assertEquals(MPCardBrand.Elo, MPCardBrand.fromString("Elo"))
     }
 
     @Test
@@ -72,43 +71,10 @@ internal class MPCardBrandTest {
     }
 
     @Test
-    fun `given every predefined brand then toString and equality execute data-object body`() {
-        val brands: List<MPCardBrand> = listOf(
-            MPCardBrand.Visa,
-            MPCardBrand.Mastercard,
-            MPCardBrand.Amex,
-            MPCardBrand.Elo,
-            MPCardBrand.Hipercard,
-            MPCardBrand.Diners,
-            MPCardBrand.Discover,
-            MPCardBrand.Jcb,
-            MPCardBrand.Maestro,
-            MPCardBrand.UnionPay,
-            MPCardBrand.Cabal,
-            MPCardBrand.Naranja,
-        )
-
-        brands.forEach { brand ->
-            assertEquals(brand, brand)
+    fun `given every predefined brand then toString is not empty`() {
+        MPCardBrand.default.forEach { brand ->
             assertTrue(brand.toString().isNotEmpty())
-            assertEquals(brand.hashCode(), brand.hashCode())
         }
-    }
-
-    @Test
-    fun `given each predefined brand then name equals expected constant`() {
-        assertEquals("visa", MPCardBrand.Visa.name)
-        assertEquals("master", MPCardBrand.Mastercard.name)
-        assertEquals("amex", MPCardBrand.Amex.name)
-        assertEquals("elo", MPCardBrand.Elo.name)
-        assertEquals("hipercard", MPCardBrand.Hipercard.name)
-        assertEquals("diners", MPCardBrand.Diners.name)
-        assertEquals("discover", MPCardBrand.Discover.name)
-        assertEquals("jcb", MPCardBrand.Jcb.name)
-        assertEquals("maestro", MPCardBrand.Maestro.name)
-        assertEquals("unionpay", MPCardBrand.UnionPay.name)
-        assertEquals("cabal", MPCardBrand.Cabal.name)
-        assertEquals("naranja", MPCardBrand.Naranja.name)
     }
 
     @Test

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/core/model/MPCheckoutTypeTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/core/model/MPCheckoutTypeTest.kt
@@ -8,19 +8,17 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 internal class MPCheckoutTypeTest {
-    private val order = MPOrder(amount = BigDecimal("100.00"), payer = MPPayer(email = "buyer@test.com"))
-
-    @Test
-    fun `given card save then it is a checkout type`() {
-        assertTrue(MPCheckoutType.CardSave is MPCheckoutType<*, *>)
-    }
+    private val order = MPOrder(
+        orderId = "ORD_TEST",
+        amount = BigDecimal("100.00"),
+        payer = MPPayer(email = "buyer@test.com"),
+    )
 
     @Test
     fun `given card transaction then exposes order`() {
         val type = MPCheckoutType.CardTransaction(order = order)
 
         assertEquals(order, type.order)
-        assertTrue(type is MPCheckoutType<*, *>)
     }
 
     @Test

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/core/model/internal/CheckoutConfigurationExtensionsTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/core/model/internal/CheckoutConfigurationExtensionsTest.kt
@@ -5,7 +5,6 @@ import com.mercadopago.sdk.android.checkout.core.model.MPInstallment
 import com.mercadopago.sdk.android.checkout.core.model.MPOrder
 import com.mercadopago.sdk.android.checkout.core.model.MPPayer
 import com.mercadopago.sdk.android.checkout.core.model.MPPaymentMethodConfig
-import com.mercadopago.sdk.android.checkout.domain.model.MPUserCancelledContext
 import java.math.BigDecimal
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -14,7 +13,11 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 internal class CheckoutConfigurationExtensionsTest {
-    private val order = MPOrder(amount = BigDecimal("188000.00"), payer = MPPayer(email = "buyer@mp.com"))
+    private val order = MPOrder(
+        orderId = "ORD_TEST",
+        amount = BigDecimal("188000.00"),
+        payer = MPPayer(email = "buyer@mp.com"),
+    )
 
     private fun configWith(
         checkoutType: MPCheckoutType<*, *>?,
@@ -82,11 +85,6 @@ internal class CheckoutConfigurationExtensionsTest {
     }
 
     @Test
-    fun `given payment cancelled context then it is a user cancelled context`() {
-        assertTrue(MPUserCancelledContext.Payment is MPUserCancelledContext)
-    }
-
-    @Test
     fun `given payment then toString and hashCode reflect its content`() {
         val checkoutType = MPCheckoutType.Payment(order = order, cardIds = listOf("1"))
         val same = MPCheckoutType.Payment(order = order, cardIds = listOf("1"))
@@ -107,22 +105,22 @@ internal class CheckoutConfigurationExtensionsTest {
 
     @Test
     fun `given card transaction when showsInstallments then returns true`() {
-        assertTrue(configWith(MPCheckoutType.CardTransaction(order)).showsInstallments())
+        assertTrue(configWith(MPCheckoutType.CardTransaction(order)).isCardTransaction())
     }
 
     @Test
     fun `given card save when showsInstallments then returns false`() {
-        assertFalse(configWith(MPCheckoutType.CardSave).showsInstallments())
+        assertFalse(configWith(MPCheckoutType.CardSave).isCardTransaction())
     }
 
     @Test
     fun `given payment when showsInstallments then returns false`() {
-        assertFalse(configWith(MPCheckoutType.Payment(order = order, cardIds = null)).showsInstallments())
+        assertFalse(configWith(MPCheckoutType.Payment(order = order, cardIds = null)).isCardTransaction())
     }
 
     @Test
     fun `given null configuration when showsInstallments then returns false`() {
-        assertFalse(configWith(null).showsInstallments())
+        assertFalse(configWith(null).isCardTransaction())
     }
 
     @Test

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/data/remote/datasource/OrderRemoteDataSourceImplTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/data/remote/datasource/OrderRemoteDataSourceImplTest.kt
@@ -1,0 +1,79 @@
+package com.mercadopago.sdk.android.checkout.data.remote.datasource
+
+import com.mercadopago.sdk.android.checkout.data.remote.request.OrderProcessRequest
+import com.mercadopago.sdk.android.checkout.data.remote.response.OrderProcessResponse
+import com.mercadopago.sdk.android.checkout.data.remote.service.OrderService
+import com.mercadopago.sdk.android.checkout.domain.model.ResponseError
+import com.mercadopago.sdk.android.checkout.domain.model.params.ProcessOrderParams
+import com.mercadopago.sdk.android.coremethods.domain.utils.Result
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import retrofit2.Response
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+internal class OrderRemoteDataSourceImplTest {
+    private val service = mockk<OrderService>()
+    private val dataSource = OrderRemoteDataSourceImpl(service)
+
+    private val params = ProcessOrderParams(
+        orderId = "ORD_789",
+        amount = "300.00",
+        paymentMethodId = "visa",
+        paymentMethodType = "credit_card",
+        token = "TOKEN_DEF",
+        installments = 6,
+    )
+
+    @Test
+    fun `given service returns successful response then process returns Result Success`() = runTest {
+        val body = mockk<OrderProcessResponse>(relaxed = true)
+        coEvery { service.process(any(), any()) } returns Response.success(body)
+
+        val result = dataSource.process(params)
+
+        assertIs<Result.Success<OrderProcessResponse>>(result)
+        assertEquals(body, result.data)
+    }
+
+    @Test
+    fun `given service returns error response then process returns Result Error`() = runTest {
+        val errorBody = """{"message":"Not Found","code":"404"}""".toResponseBody()
+        coEvery { service.process(any(), any()) } returns Response.error(404, errorBody)
+
+        val result = dataSource.process(params)
+
+        val error = assertIs<Result.Error<ResponseError>>(result)
+        assertEquals("404", error.error.code)
+        assertEquals(404, error.error.httpStatus)
+    }
+
+    @Test
+    fun `given process is called then passes orderId to service`() = runTest {
+        coEvery { service.process(any(), any()) } returns Response.success(mockk(relaxed = true))
+
+        dataSource.process(params)
+
+        coVerify { service.process(orderId = params.orderId, body = any()) }
+    }
+
+    @Test
+    fun `given process is called then passes correct body fields to service`() = runTest {
+        val bodySlot = slot<OrderProcessRequest>()
+        coEvery { service.process(any(), capture(bodySlot)) } returns
+            Response.success(mockk(relaxed = true))
+
+        dataSource.process(params)
+
+        assertEquals(params.amount, bodySlot.captured.amount)
+        assertEquals(params.paymentMethodId, bodySlot.captured.paymentMethodId)
+        assertEquals(params.paymentMethodType, bodySlot.captured.paymentMethodType)
+        assertEquals(params.token, bodySlot.captured.token)
+        assertEquals(params.installments, bodySlot.captured.installments)
+    }
+}

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/data/repository/OrderRepositoryImplTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/data/repository/OrderRepositoryImplTest.kt
@@ -1,0 +1,98 @@
+package com.mercadopago.sdk.android.checkout.data.repository
+
+import com.mercadopago.sdk.android.checkout.data.remote.datasource.OrderRemoteDataSource
+import com.mercadopago.sdk.android.checkout.data.remote.response.OrderProcessResponse
+import com.mercadopago.sdk.android.checkout.domain.model.OrderProcessOutput
+import com.mercadopago.sdk.android.checkout.domain.model.ResponseError
+import com.mercadopago.sdk.android.checkout.domain.model.params.ProcessOrderParams
+import com.mercadopago.sdk.android.coremethods.domain.utils.Result
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+internal class OrderRepositoryImplTest {
+    private val dataSource = mockk<OrderRemoteDataSource>()
+    private val repository = OrderRepositoryImpl(dataSource)
+
+    private val params = ProcessOrderParams(
+        orderId = "ORD_456",
+        amount = "200.00",
+        paymentMethodId = "master",
+        paymentMethodType = "credit_card",
+        token = "TOKEN_XYZ",
+        installments = 1,
+    )
+
+    @Test
+    fun `given dataSource returns success then returns Result Success with mapped OrderProcessOutput`() = runTest {
+        val response = OrderProcessResponse(
+            id = "ORD_456",
+            status = "approved",
+            productId = null, processingMode = null, externalReference = null,
+            description = null, totalAmount = null, totalPaidAmount = null,
+            expirationTime = null, checkoutAvailableAt = null, siteId = null,
+            userId = null, createdDate = null, lastUpdatedDate = null, type = null,
+            statusDetail = null, captureMode = null, currency = null, config = null,
+            integrationData = null, payer = null, shipment = null, transactions = null,
+            items = null,
+        )
+        coEvery { dataSource.process(params) } returns Result.Success(response)
+
+        val result = repository.process(params)
+
+        val success = assertIs<Result.Success<OrderProcessOutput>>(result)
+        assertEquals("ORD_456", success.data.id)
+        assertEquals("approved", success.data.status)
+    }
+
+    @Test
+    fun `given dataSource returns success with null fields then maps to empty strings`() = runTest {
+        val response = mockk<OrderProcessResponse>(relaxed = true) {
+            every { id } returns null
+            every { status } returns null
+        }
+        coEvery { dataSource.process(params) } returns Result.Success(response)
+
+        val result = repository.process(params)
+
+        val success = assertIs<Result.Success<OrderProcessOutput>>(result)
+        assertEquals("", success.data.id)
+        assertEquals("", success.data.status)
+    }
+
+    @Test
+    fun `given dataSource returns error then returns Result Error with same ResponseError`() = runTest {
+        val error = ResponseError(code = "404", message = "Not Found", httpStatus = 404)
+        coEvery { dataSource.process(params) } returns Result.Error(error)
+
+        val result = repository.process(params)
+
+        val resultError = assertIs<Result.Error<ResponseError>>(result)
+        assertEquals("404", resultError.error.code)
+        assertEquals("Not Found", resultError.error.message)
+        assertEquals(404, resultError.error.httpStatus)
+    }
+
+    @Test
+    fun `given dataSource throws exception then withErrorHandling catches it and returns Result Error`() = runTest {
+        coEvery { dataSource.process(params) } throws RuntimeException("Network failure")
+
+        val result = repository.process(params)
+
+        assertIs<Result.Error<ResponseError>>(result)
+    }
+
+    @Test
+    fun `given process is called then delegates params to dataSource`() = runTest {
+        coEvery { dataSource.process(params) } returns Result.Success(mockk(relaxed = true))
+
+        repository.process(params)
+
+        coVerify(exactly = 1) { dataSource.process(params) }
+    }
+}

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/CheckoutModulesProviderTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/CheckoutModulesProviderTest.kt
@@ -13,6 +13,7 @@ import com.mercadopago.sdk.android.checkout.domain.model.CardFormInitializationO
 import com.mercadopago.sdk.android.checkout.domain.model.MPInstallmentData
 import com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData
 import com.mercadopago.sdk.android.checkout.domain.usecase.GetCardBinUseCase
+import com.mercadopago.sdk.android.checkout.domain.usecase.ProcessOrderUseCase
 import com.mercadopago.sdk.android.checkout.presentation.factory.CardPaymentScreenStateFactory
 import com.mercadopago.sdk.android.checkout.presentation.usecase.CancelledFormContextUseCase
 import com.mercadopago.sdk.android.checkout.presentation.usecase.GenerateTokenUseCase
@@ -85,7 +86,7 @@ internal class CheckoutModulesProviderTest {
 
         val checkoutConfiguration = CheckoutConfiguration(
             checkoutType = MPCheckoutType.CardTransaction(
-                MPOrder(amount = BigDecimal.TEN, payer = MPPayer(email = "")),
+                MPOrder(amount = BigDecimal.TEN, payer = MPPayer(email = ""), orderId = ""),
             ),
             paymentMethodConfigs = emptyList(),
         )
@@ -109,6 +110,7 @@ internal class CheckoutModulesProviderTest {
                 CardPaymentViewModel::class,
                 GetCardBinUseCase::class,
                 GenerateTokenUseCase::class,
+                ProcessOrderUseCase::class,
                 CancelledFormContextUseCase::class,
                 Gson::class,
                 CardFormInitializationOutput::class,

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/DataModuleTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/di/DataModuleTest.kt
@@ -8,10 +8,12 @@ import com.mercadopago.sdk.android.checkout.core.model.MPOrder
 import com.mercadopago.sdk.android.checkout.core.model.MPPayer
 import com.mercadopago.sdk.android.checkout.core.model.internal.CheckoutConfiguration
 import com.mercadopago.sdk.android.checkout.data.remote.service.CardFormService
+import com.mercadopago.sdk.android.checkout.data.remote.service.OrderService
 import com.mercadopago.sdk.android.checkout.domain.model.CardFormInitializationOutput
 import com.mercadopago.sdk.android.checkout.domain.model.MPInstallmentData
 import com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData
 import com.mercadopago.sdk.android.checkout.domain.usecase.GetCardBinUseCase
+import com.mercadopago.sdk.android.checkout.domain.usecase.ProcessOrderUseCase
 import com.mercadopago.sdk.android.checkout.presentation.usecase.GenerateTokenUseCase
 import com.mercadopago.sdk.android.checkout.presentation.viewmodel.InstallmentsAnalyticsTracker
 import com.mercadopago.sdk.android.checkout.utils.MainDispatcherRule
@@ -73,7 +75,7 @@ internal class DataModuleTest {
 
         val checkoutConfiguration = CheckoutConfiguration(
             checkoutType = MPCheckoutType.CardTransaction(
-                MPOrder(amount = BigDecimal.TEN, payer = MPPayer(email = "")),
+                MPOrder(amount = BigDecimal.TEN, payer = MPPayer(email = ""), orderId = "test"),
             ),
             paymentMethodConfigs = emptyList(),
         )
@@ -82,6 +84,7 @@ internal class DataModuleTest {
             includes(provideDataModule())
             single { checkoutConfiguration }
             single { mockk<CardFormService>(relaxed = true) }
+            single { mockk<OrderService>(relaxed = true) }
         }
 
         val koin = koinApplication {
@@ -95,6 +98,7 @@ internal class DataModuleTest {
                 MPCheckoutType::class,
                 List::class,
                 CardFormService::class,
+                OrderService::class,
                 GetCardBinUseCase::class,
                 GenerateTokenUseCase::class,
                 CardFormInitializationOutput::class,
@@ -102,6 +106,7 @@ internal class DataModuleTest {
                 MPPaymentData::class,
                 String::class,
                 InstallmentsAnalyticsTracker::class,
+                ProcessOrderUseCase::class,
             ),
         )
 

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/model/MPPaymentDataTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/model/MPPaymentDataTest.kt
@@ -49,6 +49,8 @@ internal class MPPaymentDataTest {
     @Test
     fun `given card transaction data then exposes all fields`() {
         val data = MPPaymentData.CardTransaction(
+            orderId = "ORD_123",
+            orderStatus = "opened",
             transactionAmount = BigDecimal("188000.00"),
             paymentMethodId = "master",
             paymentTypeId = "credit_card",
@@ -57,6 +59,8 @@ internal class MPPaymentDataTest {
             issuerId = "310",
         )
 
+        assertEquals("ORD_123", data.orderId)
+        assertEquals("opened", data.orderStatus)
         assertEquals(BigDecimal("188000.00"), data.transactionAmount)
         assertEquals("master", data.paymentMethodId)
         assertEquals("credit_card", data.paymentTypeId)
@@ -68,6 +72,8 @@ internal class MPPaymentDataTest {
     @Test
     fun `given card transaction data when copy with new installment then equality changes`() {
         val data = MPPaymentData.CardTransaction(
+            orderId = "ORD_123",
+            orderStatus = "opened",
             transactionAmount = BigDecimal("100.00"),
             paymentMethodId = "master",
             paymentTypeId = "credit_card",
@@ -125,6 +131,8 @@ internal class MPPaymentDataTest {
     @Test
     fun `given card transaction with null optionals then exposes nulls`() {
         val data = MPPaymentData.CardTransaction(
+            orderId = "",
+            orderStatus = "",
             transactionAmount = null,
             paymentMethodId = "master",
             paymentTypeId = "credit_card",

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/usecase/ProcessOrderUseCaseTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/usecase/ProcessOrderUseCaseTest.kt
@@ -1,0 +1,97 @@
+package com.mercadopago.sdk.android.checkout.domain.usecase
+
+import com.mercadopago.sdk.android.checkout.domain.exception.ErrorCode
+import com.mercadopago.sdk.android.checkout.domain.exception.ErrorLocalized
+import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.OrderProcessOutput
+import com.mercadopago.sdk.android.checkout.domain.model.ResponseError
+import com.mercadopago.sdk.android.checkout.domain.model.params.ProcessOrderParams
+import com.mercadopago.sdk.android.checkout.domain.repository.OrderRepository
+import com.mercadopago.sdk.android.coremethods.domain.utils.Result
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+internal class ProcessOrderUseCaseTest {
+    private val repository = mockk<OrderRepository>()
+    private val useCase = ProcessOrderUseCase(repository)
+
+    private val params = ProcessOrderParams(
+        orderId = "ORD_123",
+        amount = "100.00",
+        paymentMethodId = "visa",
+        paymentMethodType = "credit_card",
+        token = "TOKEN_ABC",
+        installments = 3,
+    )
+
+    @Test
+    fun `given repository returns success then returns Result Success with OrderProcessOutput`() = runTest {
+        val output = OrderProcessOutput(id = "ORD_123", status = "approved")
+        coEvery { repository.process(params) } returns Result.Success(output)
+
+        val result = useCase(params)
+
+        val success = assertIs<Result.Success<OrderProcessOutput>>(result)
+        assertEquals("ORD_123", success.data.id)
+        assertEquals("approved", success.data.status)
+    }
+
+    @Test
+    fun `given repository returns service error then returns ServiceError localized to ORDER_PROCESS`() = runTest {
+        val error = ResponseError(code = "bad_request", message = "Service unavailable", httpStatus = 400)
+        coEvery { repository.process(params) } returns Result.Error(error)
+
+        val result = useCase(params)
+
+        val checkoutError = assertIs<Result.Error<MercadoPagoCheckoutError>>(result).error
+        assertIs<MercadoPagoCheckoutError.ServiceError>(checkoutError)
+        assertEquals(ErrorCode.SERVICE_ERROR, checkoutError.errorCode)
+        assertEquals(ErrorLocalized.ORDER_PROCESS.name, checkoutError.errorLocalized)
+    }
+
+    @Test
+    fun `given repository returns network error then returns NetworkError localized to ORDER_PROCESS`() = runTest {
+        val error = ResponseError(code = "NO_INTERNET", message = "No internet connection")
+        coEvery { repository.process(params) } returns Result.Error(error)
+
+        val result = useCase(params)
+
+        val checkoutError = assertIs<Result.Error<MercadoPagoCheckoutError>>(result).error
+        assertIs<MercadoPagoCheckoutError.NetworkError>(checkoutError)
+        assertEquals(ErrorCode.NETWORK_CONNECTION_FAILED, checkoutError.errorCode)
+        assertEquals(ErrorLocalized.ORDER_PROCESS.name, checkoutError.errorLocalized)
+    }
+
+    @Test
+    fun `given repository throws exception then withErrorHandling catches it and returns Result Error`() = runTest {
+        coEvery { repository.process(params) } throws RuntimeException("Unexpected failure")
+
+        val result = useCase(params)
+
+        assertIs<Result.Error<MercadoPagoCheckoutError>>(result)
+    }
+
+    @Test
+    fun `given repository fails then process is called exactly once — no retry`() = runTest {
+        val error = ResponseError(code = "SERVER_ERROR", message = "Internal error", httpStatus = 500)
+        coEvery { repository.process(params) } returns Result.Error(error)
+
+        useCase(params)
+
+        coVerify(exactly = 1) { repository.process(params) }
+    }
+
+    @Test
+    fun `given invoke is called then delegates params to repository`() = runTest {
+        coEvery { repository.process(params) } returns Result.Success(mockk(relaxed = true))
+
+        useCase(params)
+
+        coVerify { repository.process(params) }
+    }
+}

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/usecase/CancelledFormContextUseCaseTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/usecase/CancelledFormContextUseCaseTest.kt
@@ -16,6 +16,7 @@ import com.mercadopago.sdk.android.checkout.presentation.state.SecurityCodeState
 import com.mercadopago.sdk.android.checkout.presentation.state.ValidationState
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
 internal class CancelledFormContextUseCaseTest {
     private val useCase = CancelledFormContextUseCase()

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModelFieldEventTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModelFieldEventTest.kt
@@ -23,6 +23,7 @@ import com.mercadopago.sdk.android.checkout.domain.model.SecurityCodeField
 import com.mercadopago.sdk.android.checkout.domain.model.Validation
 import com.mercadopago.sdk.android.checkout.domain.usecase.GetCardBinUseCase
 import com.mercadopago.sdk.android.checkout.domain.usecase.InitializeCardFormUseCase
+import com.mercadopago.sdk.android.checkout.domain.usecase.ProcessOrderUseCase
 import com.mercadopago.sdk.android.checkout.presentation.factory.CardPaymentScreenStateFactory
 import com.mercadopago.sdk.android.checkout.presentation.usecase.GenerateTokenUseCase
 import com.mercadopago.sdk.android.checkout.utils.MainDispatcherRule
@@ -61,6 +62,7 @@ internal class CardPaymentViewModelFieldEventTest {
     private val getCardBinUseCase = mockk<GetCardBinUseCase>(relaxed = true)
     private val initializeCardFormUseCase = mockk<InitializeCardFormUseCase>(relaxed = true)
     private val generateTokenUseCase = mockk<GenerateTokenUseCase>(relaxed = true)
+    private val processOrderUseCase = mockk<ProcessOrderUseCase>(relaxed = true)
     private val cardPaymentScreenStateFactory = mockk<CardPaymentScreenStateFactory>(relaxed = true)
 
     private val checkoutConfiguration = CheckoutConfiguration(
@@ -104,6 +106,7 @@ internal class CardPaymentViewModelFieldEventTest {
         getCardBinUseCase = getCardBinUseCase,
         initializeCardFormUseCase = initializeCardFormUseCase,
         generateTokenUseCase = generateTokenUseCase,
+        processOrderUseCase = processOrderUseCase,
         cardPaymentScreenStateFactory = cardPaymentScreenStateFactory,
     )
 

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModelTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModelTest.kt
@@ -1,13 +1,17 @@
+@file:Suppress("NoUnusedImports")
+
 package com.mercadopago.sdk.android.checkout.presentation.viewmodel
 
 import com.mercadopago.sdk.android.analytics.domain.interactor.MPAnalytics
 import com.mercadopago.sdk.android.analytics.domain.models.Metric
+import com.mercadopago.sdk.android.checkout.analytics.OrderSubmitEventData
 import com.mercadopago.sdk.android.checkout.core.model.MPCardBrand
 import com.mercadopago.sdk.android.checkout.core.model.MPCardType
 import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType
 import com.mercadopago.sdk.android.checkout.core.model.MPPaymentMethodConfig
 import com.mercadopago.sdk.android.checkout.core.model.internal.CheckoutConfiguration
 import com.mercadopago.sdk.android.checkout.domain.callback.CheckoutCallbackHolder
+import com.mercadopago.sdk.android.checkout.domain.callback.MercadoPagoCheckoutResult
 import com.mercadopago.sdk.android.checkout.domain.exception.ErrorCode
 import com.mercadopago.sdk.android.checkout.domain.model.BinIssuer
 import com.mercadopago.sdk.android.checkout.domain.model.CardBinData
@@ -17,12 +21,16 @@ import com.mercadopago.sdk.android.checkout.domain.model.CardNumberField
 import com.mercadopago.sdk.android.checkout.domain.model.CardNumberValidation
 import com.mercadopago.sdk.android.checkout.domain.model.LengthRange
 import com.mercadopago.sdk.android.checkout.domain.model.MPInstallmentData
+import com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData
 import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.OrderProcessOutput
 import com.mercadopago.sdk.android.checkout.domain.model.Quota
 import com.mercadopago.sdk.android.checkout.domain.model.SecurityCodeField
 import com.mercadopago.sdk.android.checkout.domain.model.Validation
+import com.mercadopago.sdk.android.checkout.domain.model.params.ProcessOrderParams
 import com.mercadopago.sdk.android.checkout.domain.usecase.GetCardBinUseCase
 import com.mercadopago.sdk.android.checkout.domain.usecase.InitializeCardFormUseCase
+import com.mercadopago.sdk.android.checkout.domain.usecase.ProcessOrderUseCase
 import com.mercadopago.sdk.android.checkout.presentation.factory.CardPaymentScreenStateFactory
 import com.mercadopago.sdk.android.checkout.presentation.model.CancelReason
 import com.mercadopago.sdk.android.checkout.presentation.state.CardPaymentViewEvent
@@ -30,9 +38,14 @@ import com.mercadopago.sdk.android.checkout.presentation.state.MessageError
 import com.mercadopago.sdk.android.checkout.presentation.usecase.GenerateTokenUseCase
 import com.mercadopago.sdk.android.checkout.utils.MainDispatcherRule
 import com.mercadopago.sdk.android.coremethods.domain.model.CardToken
+import com.mercadopago.sdk.android.coremethods.domain.model.IdentificationType
 import com.mercadopago.sdk.android.coremethods.domain.utils.Result
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.cardnumber.CardNumberTextFieldEvent
+import com.mercadopago.sdk.android.coremethods.ui.components.textfield.expirationdate.ExpirationDateTextFieldEvent
+import com.mercadopago.sdk.android.coremethods.ui.components.textfield.identificationtextfield.IdentificationTextFieldEvent
 import com.mercadopago.sdk.android.coremethods.ui.components.textfield.pcitextfield.PCIFieldState
+import com.mercadopago.sdk.android.coremethods.ui.components.textfield.securitycode.SecurityCodeTextFieldEvent
+import com.mercadopago.sdk.android.coremethods.ui.components.textfield.simpletextfield.SimpleTextFieldEvent
 import com.mercadopago.sdk.android.initializer.MercadoPagoSDK
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -52,6 +65,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@Suppress("LargeClass")
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class CardPaymentViewModelTest {
     @get:Rule
@@ -61,6 +75,7 @@ internal class CardPaymentViewModelTest {
     private val getCardBinUseCase = mockk<GetCardBinUseCase>(relaxed = true)
     private val initializeCardFormUseCase = mockk<InitializeCardFormUseCase>(relaxed = true)
     private val generateTokenUseCase = mockk<GenerateTokenUseCase>(relaxed = true)
+    private val processOrderUseCase = mockk<ProcessOrderUseCase>(relaxed = true)
     private val cardPaymentScreenStateFactory = mockk<CardPaymentScreenStateFactory>(relaxed = true)
 
     private val checkoutConfiguration = CheckoutConfiguration(
@@ -104,6 +119,7 @@ internal class CardPaymentViewModelTest {
         getCardBinUseCase = getCardBinUseCase,
         initializeCardFormUseCase = initializeCardFormUseCase,
         generateTokenUseCase = generateTokenUseCase,
+        processOrderUseCase = processOrderUseCase,
         cardPaymentScreenStateFactory = cardPaymentScreenStateFactory,
     )
 
@@ -145,9 +161,9 @@ internal class CardPaymentViewModelTest {
 
         viewModel.initialization()
 
-        val metricSlot = slot<Metric>()
-        verify { mockMPAnalytics.trackMetric(capture(metricSlot)) }
-        assertTrue(metricSlot.captured.path.endsWith("/initialize_error"))
+        val metricSlots = mutableListOf<Metric>()
+        verify { mockMPAnalytics.trackMetric(capture(metricSlots)) }
+        assertTrue(metricSlots.any { it.path.endsWith("/initialize_error") })
     }
 
     @Test
@@ -193,9 +209,9 @@ internal class CardPaymentViewModelTest {
         viewModel.onCardNumberEvent(CardNumberTextFieldEvent.IsValid(isValid = true))
         viewModel.onCardNumberEvent(CardNumberTextFieldEvent.OnFocusChanged(isFocused = false))
 
-        val metricSlot = slot<Metric>()
-        verify { mockMPAnalytics.trackMetric(capture(metricSlot)) }
-        assertTrue(metricSlot.captured.path.endsWith("/input_validation"))
+        val metricSlots = mutableListOf<Metric>()
+        verify { mockMPAnalytics.trackMetric(capture(metricSlots)) }
+        assertTrue(metricSlots.any { it.path.endsWith("/input_validation") })
     }
 
     @Test
@@ -282,6 +298,113 @@ internal class CardPaymentViewModelTest {
     }
 
     @Test
+    fun `when ExpirationDate IsValid then updates isValid`() = runTest {
+        val viewModel = makeViewModel()
+
+        viewModel.onExpirationDateEvent(ExpirationDateTextFieldEvent.IsValid(isValid = true))
+
+        assertTrue(viewModel.viewState.value.expirationDateState.isValid)
+    }
+
+    @Test
+    fun `when ExpirationDate IsValid event then tracks input_validation`() = runTest {
+        val viewModel = makeViewModel()
+
+        viewModel.onExpirationDateEvent(ExpirationDateTextFieldEvent.IsValid(isValid = false))
+
+        val metricSlots = mutableListOf<Metric>()
+        verify { mockMPAnalytics.trackMetric(capture(metricSlots)) }
+        assertTrue(metricSlots.any { it.path.endsWith("/input_validation") })
+    }
+
+    @Test
+    fun `when ExpirationDate OnLengthChanged then updates length`() = runTest {
+        val viewModel = makeViewModel()
+
+        viewModel.onExpirationDateEvent(ExpirationDateTextFieldEvent.OnLengthChanged(length = 3))
+
+        assertEquals(3, viewModel.viewState.value.expirationDateState.length)
+    }
+
+    @Test
+    fun `when ExpirationDate OnInputFilled then updates filled`() = runTest {
+        val viewModel = makeViewModel()
+
+        viewModel.onExpirationDateEvent(ExpirationDateTextFieldEvent.OnInputFilled(isFilled = true))
+
+        assertTrue(viewModel.viewState.value.expirationDateState.filled)
+    }
+
+    @Test
+    fun `when SecurityCode OnLengthChanged then updates length`() = runTest {
+        val viewModel = makeViewModel()
+
+        viewModel.onSecurityCodeEvent(SecurityCodeTextFieldEvent.OnLengthChanged(length = 2))
+
+        assertEquals(2, viewModel.viewState.value.secureCodeState.length)
+    }
+
+    @Test
+    fun `when SecurityCode OnInputFilled then updates filled`() = runTest {
+        val viewModel = makeViewModel()
+
+        viewModel.onSecurityCodeEvent(SecurityCodeTextFieldEvent.OnInputFilled(isFilled = true))
+
+        assertTrue(viewModel.viewState.value.secureCodeState.filled)
+    }
+
+    @Test
+    fun `when CardHolder OnValueChanged then updates value`() = runTest {
+        val viewModel = makeViewModel()
+
+        viewModel.onCardHolderEvent(SimpleTextFieldEvent.OnValueChanged("John Doe"))
+
+        assertEquals("John Doe", viewModel.viewState.value.cardHolderState.value)
+    }
+
+    @Test
+    fun `when CardHolder OnFocusChanged false then isFocused is false`() = runTest {
+        val viewModel = makeViewModel()
+
+        viewModel.onCardHolderEvent(SimpleTextFieldEvent.OnFocusChanged(isFocused = false))
+
+        assertFalse(viewModel.viewState.value.cardHolderState.isFocused)
+    }
+
+    @Test
+    fun `when Identification OnValueChanged then updates value`() = runTest {
+        val viewModel = makeViewModel()
+
+        viewModel.onIdentificationEvent(IdentificationTextFieldEvent.OnValueChanged("12345678"))
+
+        assertEquals("12345678", viewModel.viewState.value.identificationTypeState.value)
+    }
+
+    @Test
+    fun `when Identification OnTypeSelected then tracks dropdown_selection`() = runTest {
+        val viewModel = makeViewModel()
+
+        viewModel.onIdentificationEvent(
+            IdentificationTextFieldEvent.OnTypeSelected(mockk<IdentificationType>(relaxed = true)),
+        )
+
+        val metricSlots = mutableListOf<Metric>()
+        verify { mockMPAnalytics.trackMetric(capture(metricSlots)) }
+        assertTrue(metricSlots.any { it.path.endsWith("/dropdown_selection") })
+    }
+
+    @Test
+    fun `when Identification OnTypeSelected then updates selected and clears placeholder`() = runTest {
+        val viewModel = makeViewModel()
+        val identificationType = mockk<IdentificationType>(relaxed = true)
+
+        viewModel.onIdentificationEvent(IdentificationTextFieldEvent.OnTypeSelected(identificationType))
+
+        assertEquals(identificationType, viewModel.viewState.value.identificationTypeState.selected)
+        assertEquals("", viewModel.viewState.value.identificationTypeState.placeHolder)
+    }
+
+    @Test
     fun `when onTooltipClick called once then showTooltip is true`() = runTest {
         val viewModel = makeViewModel()
 
@@ -325,9 +448,9 @@ internal class CardPaymentViewModelTest {
 
         viewModel.onBackPressed()
 
-        val metricSlot = slot<Metric>()
-        verify { mockMPAnalytics.trackMetric(capture(metricSlot)) }
-        assertTrue(metricSlot.captured.path.endsWith("/user_canceled_error"))
+        val metricSlots = mutableListOf<Metric>()
+        verify { mockMPAnalytics.trackMetric(capture(metricSlots)) }
+        assertTrue(metricSlots.any { it.path.endsWith("/user_canceled_error") })
     }
 
     @Test
@@ -356,11 +479,15 @@ internal class CardPaymentViewModelTest {
     }
 
     @Test
-    fun `when onSubmit succeeds then tracks submit event`() = runTest {
+    fun `when onSubmit succeeds with CardSave then tracks submit event`() = runTest {
+        val cardSaveConfig = CheckoutConfiguration(
+            checkoutType = MPCheckoutType.CardSave,
+            paymentMethodConfigs = emptyList(),
+        )
         coEvery {
             generateTokenUseCase(any(), any(), any(), any())
         } returns Result.Success(CardToken(token = "token_abc"))
-        val viewModel = makeViewModel()
+        val viewModel = makeViewModel(config = cardSaveConfig)
 
         viewModel.onSubmit(
             cardNumberState = mockk<PCIFieldState>(relaxed = true),
@@ -368,9 +495,34 @@ internal class CardPaymentViewModelTest {
             securityCodeState = mockk<PCIFieldState>(relaxed = true),
         )
 
-        val metricSlot = slot<Metric>()
-        verify { mockMPAnalytics.trackMetric(capture(metricSlot)) }
-        assertTrue(metricSlot.captured.path.endsWith("/submit"))
+        val metricSlots = mutableListOf<Metric>()
+        verify { mockMPAnalytics.trackMetric(capture(metricSlots)) }
+        assertTrue(metricSlots.any { it.path.endsWith("/submit") })
+    }
+
+    @Test
+    fun `when onInstallmentConfirmed succeeds then tracks order submit event with order data`() = runTest {
+        coEvery {
+            generateTokenUseCase(any(), any(), any(), any())
+        } returns Result.Success(CardToken(token = "token_abc"))
+        coEvery { processOrderUseCase(any()) } returns
+            Result.Success(OrderProcessOutput(id = "order_123", status = "opened"))
+        val viewModel = makeViewModel()
+        viewModel.onSubmit(
+            cardNumberState = mockk<PCIFieldState>(relaxed = true),
+            expirationDateState = mockk<PCIFieldState>(relaxed = true),
+            securityCodeState = mockk<PCIFieldState>(relaxed = true),
+        )
+        viewModel.onViewEventConsumed()
+
+        viewModel.onInstallmentConfirmed(installment = 3)
+
+        val metricSlots = mutableListOf<Metric>()
+        verify { mockMPAnalytics.trackMetric(capture(metricSlots)) }
+        val orderSubmitMetric = metricSlots.first { it.path.endsWith("/order/submit") }
+        val data = orderSubmitMetric.data as OrderSubmitEventData
+        assertEquals("order_123", data.orderId)
+        assertEquals("opened", data.orderStatus)
     }
 
     @Test

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/InstallmentsAnalyticsTrackerTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/InstallmentsAnalyticsTrackerTest.kt
@@ -16,6 +16,8 @@ internal class InstallmentsAnalyticsTrackerTest {
         payer = null,
         installment = null,
         issuerId = "1",
+        orderId = "123",
+        orderStatus = "approved",
     )
 
     private val installmentData = MPInstallmentData(
@@ -35,6 +37,7 @@ internal class InstallmentsAnalyticsTrackerTest {
         checkoutType = "card_form",
         paymentData = paymentData,
         installmentData = installmentData,
+        orderId = "order",
     )
 
     @Test

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/InstallmentsViewModelTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/InstallmentsViewModelTest.kt
@@ -39,6 +39,8 @@ internal class InstallmentsViewModelTest {
         payer = null,
         installment = null,
         issuerId = "1",
+        orderId = "123",
+        orderStatus = "approved",
     )
 
     private fun makeData(
@@ -61,6 +63,7 @@ internal class InstallmentsViewModelTest {
         installmentData = installmentData,
         paymentData = paymentData,
         checkoutType = "card_form",
+        orderId = "order_123",
         analyticsTracker = tracker,
     )
 

--- a/example/src/main/java/com/mercadopago/sdk/android/example/navigation/SampleDestination.kt
+++ b/example/src/main/java/com/mercadopago/sdk/android/example/navigation/SampleDestination.kt
@@ -16,6 +16,9 @@ internal sealed interface SampleDestination {
 
     @Serializable
     object Checkout : SampleDestination
+
+    @Serializable
+    object CardTransaction : SampleDestination
 }
 
 internal fun SampleDestination.isRoute(route: String?): Boolean {

--- a/example/src/main/java/com/mercadopago/sdk/android/example/navigation/SampleFeaturesNavigationList.kt
+++ b/example/src/main/java/com/mercadopago/sdk/android/example/navigation/SampleFeaturesNavigationList.kt
@@ -19,6 +19,12 @@ internal val SampleFeaturesNavigationList: List<SampleFeature> = listOf(
         description = R.string.checkout_feature_description,
         destination = SampleDestination.Checkout,
         isEnabled = true,
+    ),
+    SampleFeature(
+        title = R.string.card_transaction_feature_title,
+        description = R.string.card_transaction_feature_description,
+        destination = SampleDestination.CardTransaction,
+        isEnabled = true,
     )
 )
 

--- a/example/src/main/java/com/mercadopago/sdk/android/example/presentation/cardpayment/CardTransactionExampleScreen.kt
+++ b/example/src/main/java/com/mercadopago/sdk/android/example/presentation/cardpayment/CardTransactionExampleScreen.kt
@@ -1,0 +1,283 @@
+package com.mercadopago.sdk.android.example.presentation.cardpayment
+
+import android.content.ClipData
+import android.content.ClipDescription
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import android.os.PersistableBundle
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.mercadopago.sdk.android.checkout.core.MercadoPagoCheckout
+import com.mercadopago.sdk.android.checkout.core.model.MPCheckoutType
+import com.mercadopago.sdk.android.checkout.core.model.MPOrder
+import com.mercadopago.sdk.android.checkout.core.model.MPPayer
+import com.mercadopago.sdk.android.checkout.core.model.MPPaymentMethodConfig
+import com.mercadopago.sdk.android.checkout.domain.callback.MercadoPagoCheckoutResult
+import com.mercadopago.sdk.android.example.presentation.theme.MercadoPagoSampleTheme
+import kotlinx.coroutines.launch
+import java.math.BigDecimal
+
+private sealed interface CardTransactionState {
+    data object Idle : CardTransactionState
+    data class Success(val orderStatus: String) : CardTransactionState
+}
+
+@Composable
+internal fun CardTransactionExampleScreen(
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    var state by remember { mutableStateOf<CardTransactionState>(CardTransactionState.Idle) }
+
+    val checkout = remember {
+        MercadoPagoCheckout.Builder(
+            context = context,
+            checkoutType = MPCheckoutType.CardTransaction(
+                order = MPOrder(
+                    orderId = "MOCK_ORD_APPROVED",
+                    amount = BigDecimal(100),
+                    payer = MPPayer(email = "test"),
+                ),
+            ),
+        ).setPaymentMethodConfiguration(listOf(MPPaymentMethodConfig.Card()))
+            .build()
+    }
+
+    when (val current = state) {
+        CardTransactionState.Idle -> Scaffold(
+            modifier = modifier.fillMaxSize(),
+        ) { padding ->
+            CardTransactionIdleContent(
+                modifier = Modifier.padding(padding),
+                onStartTransaction = {
+                    checkout.show { result ->
+                        when (result) {
+                            is MercadoPagoCheckoutResult.Success ->
+                                state = CardTransactionState.Success(result.paymentData.orderStatus)
+
+                            is MercadoPagoCheckoutResult.Error ->
+                                // Avoid exposing raw gateway messages (may contain internal details)
+                                Toast.makeText(
+                                    context,
+                                    "Ocorreu um erro ao processar o pagamento",
+                                    Toast.LENGTH_LONG,
+                                ).show()
+
+                            is MercadoPagoCheckoutResult.UserCancelled -> {
+                                val fieldsInfo = result.cancelledData.fields
+                                    .joinToString(", ") { "${it.field.name}: ${it.state::class.simpleName}" }
+                                Toast.makeText(
+                                    context,
+                                    "Cancelado\nfields=$fieldsInfo",
+                                    Toast.LENGTH_LONG,
+                                ).show()
+                            }
+                        }
+                    }
+                },
+            )
+        }
+
+        is CardTransactionState.Success -> CardTransactionSuccessContent(
+            orderStatus = current.orderStatus,
+            modifier = modifier.fillMaxSize(),
+        )
+    }
+}
+
+@Composable
+private fun CardTransactionIdleContent(
+    onStartTransaction: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+    ) {
+        Spacer(modifier = Modifier.height(40.dp))
+
+        Text(
+            text = "Card Transaction",
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+            text = "Inicie uma transação com cartão usando MPCheckoutType.CardTransaction",
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Button(
+            onClick = onStartTransaction,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp),
+            shape = RoundedCornerShape(14.dp),
+        ) {
+            Text(
+                text = "Iniciar transação",
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(28.dp))
+    }
+}
+
+@Composable
+private fun CardTransactionSuccessContent(
+    orderStatus: String,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Default.CheckCircle,
+                contentDescription = null,
+                tint = Color(0xFF00A650),
+                modifier = Modifier.size(72.dp),
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                text = "Transação concluída",
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                tonalElevation = 2.dp,
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 4.dp, top = 4.dp, bottom = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = orderStatus,
+                        modifier = Modifier.weight(1f),
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f),
+                        maxLines = 3,
+                        fontWeight = FontWeight.Medium,
+                    )
+                    IconButton(
+                        onClick = {
+                            val clip = ClipData.newPlainText("orderStatus", orderStatus).also { clipData ->
+                                // Hide from clipboard history/previews on Android 13+ (EXTRA_IS_SENSITIVE)
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                    clipData.description.extras = PersistableBundle().apply {
+                                        putBoolean(ClipDescription.EXTRA_IS_SENSITIVE, true)
+                                    }
+                                }
+                            }
+                            (context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager)
+                                .setPrimaryClip(clip)
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar("Status copiado!")
+                            }
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.ContentCopy,
+                            contentDescription = "Copiar status",
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = "status do pedido retornado pelo checkout",
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CardTransactionIdlePreview() {
+    MercadoPagoSampleTheme {
+        CardTransactionIdleContent(onStartTransaction = {})
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CardTransactionSuccessPreview() {
+    MercadoPagoSampleTheme {
+        CardTransactionSuccessContent(orderStatus = "approved")
+    }
+}

--- a/example/src/main/java/com/mercadopago/sdk/android/example/presentation/home/SampleNavHost.kt
+++ b/example/src/main/java/com/mercadopago/sdk/android/example/presentation/home/SampleNavHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.mercadopago.sdk.android.example.navigation.SampleDestination
+import com.mercadopago.sdk.android.example.presentation.cardpayment.CardTransactionExampleScreen
 import com.mercadopago.sdk.android.example.presentation.checkout.CheckoutExampleScreen
 import com.mercadopago.sdk.android.example.presentation.coremethods.PaymentExampleScreen
 import com.mercadopago.sdk.android.example.presentation.features.SampleFeaturesScreen
@@ -40,6 +41,9 @@ internal fun SampleNavHost(
         }
         composable<SampleDestination.Checkout> {
             CheckoutExampleScreen()
+        }
+        composable<SampleDestination.CardTransaction> {
+            CardTransactionExampleScreen()
         }
     }
 }

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -13,4 +13,6 @@
     <string name="checkout_feature_title">Checkout</string>
     <string name="checkout_feature_description">The Checkout feature offers a seamless payment experience without requiring any component building. You can leverage one of the default themes or customize your own to create a complete payment solution.</string>
     <string name="payment_button_text">Pay</string>
+    <string name="card_transaction_feature_title">Card Transaction</string>
+    <string name="card_transaction_feature_description">Demonstrates MPCheckoutType.CardTransaction, which processes a card payment linked to an existing order.</string>
 </resources>


### PR DESCRIPTION
## Summary

- Replaces the non-atomic `isLoading` guard in `onInstallmentConfirmed` with `AtomicBoolean.compareAndSet`, preventing a race condition where two rapid taps could both pass the check before either one set `isLoading = true`

## Changes

- `CardPaymentViewModel` — `private val isProcessingOrder = AtomicBoolean(false)`, guard via `compareAndSet(false, true)`, reset after `processOrder` completes

## Test plan

- [ ] Rapid double-tap on confirm button no longer triggers duplicate order submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)