### PR TITLE
[SKILL TEST] feat(components): sync MPTooltip maxWidth with Flowbook CVV spec

### DIFF
--- a/components/src/main/java/com/mercadopago/sdk/android/components/MPTooltip.kt
+++ b/components/src/main/java/com/mercadopago/sdk/android/components/MPTooltip.kt
@@ -25,13 +25,13 @@ private const val TOOLTIP_GROUP = "Tooltip"
  *
  * @param text the contextual label to display
  * @param modifier component modifier
- * @param maxWidth maximum width constraint; defaults to 280.dp
+ * @param maxWidth maximum width constraint; defaults to 296.dp per Flowbook CVV tooltip spec
  */
 @Composable
 fun MPTooltip(
     text: String,
     modifier: Modifier = Modifier,
-    maxWidth: Dp = 280.dp,
+    maxWidth: Dp = 296.dp,
 ) {
     val shape = MercadoPagoTheme.shape.tiny
     MPText(
@@ -79,6 +79,23 @@ internal fun TooltipFixedPreview() {
             MPTooltip(
                 text = "Label",
                 modifier = Modifier.padding(horizontal = MercadoPagoTheme.spacing.paddings.small),
+            )
+        }
+    }
+}
+
+@Preview(name = "Tooltip - CVV", group = TOOLTIP_GROUP)
+@Composable
+internal fun TooltipCvvPreview() {
+    MercadoPagoTheme(theme = MercadoPagoThemes.Default) {
+        Column(
+            modifier = Modifier
+                .background(Color.White)
+                .padding(16.dp),
+        ) {
+            MPTooltip(
+                text = "Ingresá el código de 3 dígitos que aparece en el reverso de tu tarjeta.",
+                maxWidth = 296.dp,
             )
         }
     }


### PR DESCRIPTION
> ⚠️ **Este é um PR de teste da skill `flowbook-pr`** — não mergear. Criado automaticamente para validar o fluxo de sync nativo (Passo 6).

---

## Sincronização com Flowbook

Mudanças nativas que refletem o PR do Flowbook:
https://github.com/melisource/fury_openplatform-sdk-android/pull/45

## Componentes atualizados

- **MPTooltip**: `maxWidth` default atualizado de `280.dp` → `296.dp`

## Mudanças aplicadas

| Propriedade | Antes | Depois | Fonte |
|---|---|---|---|
| `maxWidth` default | `280.dp` | `296.dp` | Flowbook: `#mla-cvv-tooltip { width: 296px }` |

- Preview `Tooltip - CVV` adicionado mostrando a variante com texto de CVV e `maxWidth = 296.dp`

## MAPA DE IMPACTO NATIVO (Passo 6.0)

```
MAPA DE IMPACTO NATIVO
├── Tem mudanças com impacto nativo? SIM
├── Componentes afetados:
│   └── cvv-tooltip (Flowbook)
│       ├── Tipo: update
│       ├── Mudanças detectadas:
│       │   └── Visual: width 296px (antes implícito/wrap)
│       ├── Android: MPTooltip.kt ✅
│       └── iOS: MPTooltip.swift ✅ (criado — ver PR do iOS)
└── Componentes sem equivalente nativo (criar do zero): nenhum
```

## Checklist
- [x] Nenhum valor hardcoded introduzido (o `296.dp` é o default do parâmetro — o chamador pode sobrescrever)
- [x] Mudança backward-compatible (parâmetro com default)
- [x] Preview adicionado para o novo caso de uso
- [ ] Compilação (não executada — PR de teste de skill)
- [ ] ktlint (não executado — PR de teste de skill)

## PR iOS correspondente
https://github.com/melisource/fury_openplatform-sdk-ios/pull/new/feat/skill-test-sync-flowbook-pr45-ios
(link atualizado após abertura do PR iOS)