### PR TITLE
fix(build): increase Gradle heap, disable parallel builds, add Dokka

### DIFF
--- a/checkout/build.gradle.kts
+++ b/checkout/build.gradle.kts
@@ -93,6 +93,19 @@ android {
     lint {
         disable += "NullSafeMutableLiveData"
     }
+    apply(plugin = "org.jetbrains.dokka")
+}
+
+tasks.named(MercadoPagoSDKConfig.DOKKA_HTML, org.jetbrains.dokka.gradle.DokkaTask::class).configure {
+    outputDirectory.set(layout.buildDirectory.dir(MercadoPagoSDKConfig.DOKKA_DIR))
+    dokkaSourceSets {
+        configureEach {
+            perPackageOption {
+                matchingRegex.set(MercadoPagoSDKConfig.DOKKA_IGNORE_PACKAGES)
+                suppress.set(true)
+            }
+        }
+    }
 }
 
 ksp {

--- a/foundation/build.gradle.kts
+++ b/foundation/build.gradle.kts
@@ -68,6 +68,19 @@ android {
             "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
         )
     }
+    apply(plugin = "org.jetbrains.dokka")
+}
+
+tasks.named(MercadoPagoSDKConfig.DOKKA_HTML, org.jetbrains.dokka.gradle.DokkaTask::class).configure {
+    outputDirectory.set(layout.buildDirectory.dir(MercadoPagoSDKConfig.DOKKA_DIR))
+    dokkaSourceSets {
+        configureEach {
+            perPackageOption {
+                matchingRegex.set(MercadoPagoSDKConfig.DOKKA_IGNORE_PACKAGES)
+                suppress.set(true)
+            }
+        }
+    }
 }
 
 kover {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,12 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+kotlin.daemon.jvm.options=-Xmx2g -XX:MaxMetaspaceSize=512m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
+org.gradle.parallel=false
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
<!-- No ticket associated — build infrastructure fix -->

## Description

Two independent build infrastructure issues addressed: a Gradle daemon OOM crash in CI (daemon killed during `analytics:compileReleaseKotlin`) and missing Dokka configuration that was silently excluding `checkout` and `foundation` from the multi-module documentation site.

### Fixed
- Gradle build daemon OOM crash in CI — daemon was killed during `analytics:compileReleaseKotlin` due to memory exhaustion with `-Xmx2048m`

### Changed
- `org.gradle.jvmargs` bumped from `-Xmx2048m` to `-Xmx3g -XX:MaxMetaspaceSize=512m` — prevents daemon OOM on CircleCI
- `kotlin.daemon.jvm.options` set to `-Xmx2g -XX:MaxMetaspaceSize=512m` — Kotlin compiler daemon now has its own heap budget instead of competing with the Gradle daemon
- `org.gradle.parallel` set to `false` — prevents two Kotlin compiler daemons from running concurrently and exhausting available memory

### Added
- Dokka plugin applied to `checkout` and `foundation` modules — both were missing `apply(plugin = "org.jetbrains.dokka")`, so `dokkaHtmlMultiModule` was silently skipping their sources; now included in the generated documentation site at `build/dokka/htmlMultiModule`

```kotlin
// gradle.properties — before
org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
// org.gradle.parallel=true

// gradle.properties — after
org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
kotlin.daemon.jvm.options=-Xmx2g -XX:MaxMetaspaceSize=512m
org.gradle.parallel=false
```

```kotlin
// checkout/build.gradle.kts and foundation/build.gradle.kts — added inside android {} block
apply(plugin = "org.jetbrains.dokka")

// and corresponding task configuration
tasks.named(MercadoPagoSDKConfig.DOKKA_HTML, org.jetbrains.dokka.gradle.DokkaTask::class).configure {
    outputDirectory.set(layout.buildDirectory.dir(MercadoPagoSDKConfig.DOKKA_DIR))
    dokkaSourceSets {
        configureEach {
            perPackageOption {
                matchingRegex.set(MercadoPagoSDKConfig.DOKKA_IGNORE_PACKAGES)
                suppress.set(true)
            }
        }
    }
}
```

## Checklist
- [x] New and existing unit tests pass locally with my changes.
- [x] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes creating a local version (More info in README file).
- [ ] I have added tests that prove my solution is effective and works
- [ ] Verify that you are merged with the latest in develop.
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
<!-- No UI changes — build infrastructure only -->
