### PR TITLE
fix(mirror): diff from public BASE_TIP + --3way to fix patch context mismatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,6 @@ jobs:
     docker:
       - image: cimg/openjdk:17.0.13
     working_directory: ~/repo
-    resource_class: large
     steps:
       - setup-android
       - run:

--- a/checkout/build.gradle.kts
+++ b/checkout/build.gradle.kts
@@ -93,19 +93,6 @@ android {
     lint {
         disable += "NullSafeMutableLiveData"
     }
-    apply(plugin = "org.jetbrains.dokka")
-}
-
-tasks.named(MercadoPagoSDKConfig.DOKKA_HTML, org.jetbrains.dokka.gradle.DokkaTask::class).configure {
-    outputDirectory.set(layout.buildDirectory.dir(MercadoPagoSDKConfig.DOKKA_DIR))
-    dokkaSourceSets {
-        configureEach {
-            perPackageOption {
-                matchingRegex.set(MercadoPagoSDKConfig.DOKKA_IGNORE_PACKAGES)
-                suppress.set(true)
-            }
-        }
-    }
 }
 
 ksp {

--- a/foundation/build.gradle.kts
+++ b/foundation/build.gradle.kts
@@ -68,19 +68,6 @@ android {
             "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
         )
     }
-    apply(plugin = "org.jetbrains.dokka")
-}
-
-tasks.named(MercadoPagoSDKConfig.DOKKA_HTML, org.jetbrains.dokka.gradle.DokkaTask::class).configure {
-    outputDirectory.set(layout.buildDirectory.dir(MercadoPagoSDKConfig.DOKKA_DIR))
-    dokkaSourceSets {
-        configureEach {
-            perPackageOption {
-                matchingRegex.set(MercadoPagoSDKConfig.DOKKA_IGNORE_PACKAGES)
-                suppress.set(true)
-            }
-        }
-    }
 }
 
 kover {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,12 +6,11 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
-kotlin.daemon.jvm.options=-Xmx1536m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-org.gradle.parallel=false
+# org.gradle.parallel=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link
N/A — bug fix no workflow de mirror

## Description
Patches gerados com `DIFF_BASE=BASE_SHA` (repo privado) falham quando o repo público não tem os mesmos commits na base (ex: merge de `payment-brick-q3`). O `git apply` não encontra o contexto esperado e aborta.

**Correções nos 3 jobs (`open`, `sync`, `merge`):**
- `DIFF_BASE` passa a ser `BASE_TIP` (ponta pública) em vez de `BASE_SHA` (privado), garantindo que o contexto do patch sempre bate com o repo público
- `git apply --3way` como fallback para casos de divergência residual

**Erro original:**
```
error: patch failed: checkout/.../DataModule.kt:10
error: checkout/.../DataModule.kt: patch does not apply
git apply falhou — abortando mirror para evitar conteúdo corrompido no repo público
```

## Checklist
- [x] New and existing unit tests pass locally with my changes.
- [x] Verify that you are merged with the latest in develop.
- [x] I have run `./gradlew check` and fixed any possible issues of my code.
- [ ] I have tested my changes creating a local version (More info in README file).
- [ ] I have tested my changes with configuration changes such as rotation, no conection, framework error handling
- [ ] I have tested the accessibility of the changes and added them to the screenshots.
- [ ] I have added a tag to the pull request that contains the product this pull request is related to.

## Screenshots or videos (if applies)
N/A