### PR TITLE
[CHOBK-4937] Add native CoreMethods and Checkout error observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Paparazzi snapshot images removed from git tracking — LFS objects were missing on the server (404); directory added to `.gitignore`
 
 ### Added
+- Best-effort native error observability for the existing CoreMethods and Checkout error seams. Reports use a closed, privacy-safe catalog, a bounded single-worker queue, and a credential-free transport; existing Melidata events share the same correlation ID.
+- Native error delivery is compiled in `DUAL_WRITE` mode for migration validation. The public SDK API and Checkout callbacks remain unchanged, and source gates must stay disabled until trusted-signal corroboration, privacy/security approval, and the rollout checks are complete.
 - `MPCheckoutType.CardTransaction` — initiates a card payment against an existing order via `MPOrder(orderId, clientToken, amount, payer)`
 - `MPPaymentData.CardTransaction` — success result carrying `orderId`, `orderStatus`, and `paymentMethodId`
 - `MPUserCancelledContext.CardTransaction` — cancellation context with `fields` (list of `MPCancelledFieldState`) and `screens` visited

--- a/OBSERVABILITY_VALIDATION.md
+++ b/OBSERVABILITY_VALIDATION.md
@@ -1,0 +1,37 @@
+# Android native error observability validation
+
+Date: 2026-09-02
+
+Parent: CHOBK-3831
+
+Initiative: `observability-initiative`
+
+## Repository validation
+
+- `:analytics:testDebugUnitTest`, `:core-methods:testDebugUnitTest`, and `:checkout:testDebugUnitTest` passed, including the shared Android Checkout fixture, all existing affected operation paths, queue saturation/cleanup, transport containment, and identical public Checkout error assertions.
+- `detekt ktlintCheck` passed after applying the repository format and documentation rules to the feature diff.
+- `:analytics:lintDebug`, `:core-methods:lintDebug`, `:checkout:lintDebug`, and `:sdk-android:lintDebug` passed.
+- `assembleDebug assembleRelease :example:assembleRelease --parallel` passed. Release artifacts were minified by R8 without a new broad consumer keep rule.
+- `AnalyticsModulesProviderTest` and `MPAnalyticsTest` passed after the final formatting and annotation fixes, covering reporter bindings and graph cleanup.
+- No documented public constructor, model, callback, or method signature was changed. New JVM-visible cross-module observability symbols are restricted to `LIBRARY_GROUP`; this repository does not configure a separate ABI-diff Gradle task.
+
+## Compatibility and rollout constraints
+
+- Existing `Result` values, Checkout view events, and callbacks preserve their original public errors. Observability is an internal best-effort side effect.
+- The reporter owns one worker and a 64-element bounded queue. The dedicated client has no credential/public-key interceptor, retry, redirect, cookie, cache, or logger.
+- `DUAL_WRITE` preserves Melidata during validation. No source gate, release, deployment, dashboard, monitor, or cutover was performed by this repository task.
+- Source gates must remain disabled until the backend contract is deployed and the external operational, trusted-corroboration, performance, privacy, and security handoffs are complete.
+
+## Performance review
+
+- `MPErrorReporter.track` performs no await, blocking I/O, retry, logging, or task-per-event work. It uses one `SupervisorJob` worker and a fixed 64-element `Channel`; saturation drops the newest report immediately.
+- `MPErrorReporterTest.caller path p95 stays below one millisecond under queue pressure` exercises the production UUID/timestamp path after warm-up and enforces the `<1ms` p95 caller-path budget while the queue is saturated.
+- Reporter replacement closes the previous channel, cancels its single scope, and closes the previous Koin graph. Existing lifecycle tests cover reconfiguration and cleanup.
+- The `<1%` CoreMethods/Checkout public-operation latency comparison requires coordinated release E2E measurements and remains a rollout handoff; it is not evidence that can be produced by JVM unit tests.
+
+## Security and privacy review
+
+- The request is constructed from closed enums and explicitly bounded optional fields. Tests reject serialization of credentials, cookies, PAN/BIN/CVV, payer data, order/payment identifiers, package/device identifiers, URLs/bodies, raw errors/messages, and arbitrary detail keys.
+- The dedicated client sends no authorization or cookie header, refuses redirects, disables application retry, uses bounded timeouts, and does not install logging, caching, credential, or public-key interceptors.
+- No report is persisted or replayed. Transport, queue, serialization, and analytics failures are contained without logging raw input or changing the product result.
+- ApplicationSecurityMCP was unavailable in this local agent runtime. Its issue catalog/fix-suggestion scan and the required AppSec approval remain explicit external handoffs before any source gate, paging, or observability-only cutover can be enabled.

--- a/analytics/build.gradle.kts
+++ b/analytics/build.gradle.kts
@@ -39,6 +39,7 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
+        buildConfigField("String", "NATIVE_ERROR_DELIVERY_MODE", "\"DUAL_WRITE\"")
     }
 
     buildTypes {
@@ -57,6 +58,9 @@ android {
     kotlinOptions {
         jvmTarget = MercadoPagoSDKConfig.JVM_TARGET
     }
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies {
@@ -68,6 +72,9 @@ dependencies {
 
     implementation(libs.converter.gson)
     implementation(libs.converter.kotlinx.serialization)
+    implementation(libs.squareup.retrofit)
+    implementation(libs.okhttp)
+    implementation(libs.kotlin.coroutines.core)
 
     api(libs.androidx.datastore)
 
@@ -77,6 +84,7 @@ dependencies {
     testImplementation(libs.koin.test.junit4)
     testImplementation(libs.cashapp.turbine)
     testImplementation(libs.kotlin.coroutines.test)
+    testImplementation(libs.okhttp.mockWebServer)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/datasource/remote/NativeErrorRemoteDataSource.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/datasource/remote/NativeErrorRemoteDataSource.kt
@@ -1,0 +1,7 @@
+package com.mercadopago.sdk.android.analytics.data.datasource.remote
+
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorRequest
+
+internal interface NativeErrorRemoteDataSource {
+    suspend fun report(request: NativeErrorRequest): Boolean
+}

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/datasource/remote/NativeErrorRemoteDataSourceImpl.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/datasource/remote/NativeErrorRemoteDataSourceImpl.kt
@@ -1,0 +1,21 @@
+package com.mercadopago.sdk.android.analytics.data.datasource.remote
+
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorRequest
+import com.mercadopago.sdk.android.analytics.data.remote.service.NativeErrorService
+import kotlinx.coroutines.CancellationException
+
+internal class NativeErrorRemoteDataSourceImpl(
+    private val service: NativeErrorService,
+) : NativeErrorRemoteDataSource {
+    override suspend fun report(request: NativeErrorRequest): Boolean = try {
+        service.report(request).code() == HTTP_ACCEPTED
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (_: Exception) {
+        false
+    }
+
+    private companion object {
+        const val HTTP_ACCEPTED = 202
+    }
+}

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/remote/mapper/NativeErrorRequestMapper.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/remote/mapper/NativeErrorRequestMapper.kt
@@ -1,0 +1,70 @@
+package com.mercadopago.sdk.android.analytics.data.remote.mapper
+
+import android.content.Context
+import android.os.Build
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorDetailRequest
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorDeviceRequest
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorRequest
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorSourceRequest
+import com.mercadopago.sdk.android.analytics.domain.models.PendingNativeError
+import com.mercadopago.sdk.android.core.BuildConfig
+import com.mercadopago.sdk.android.core.utils.NetworkType
+import com.mercadopago.sdk.android.core.utils.checkNetworkType
+
+internal class NativeErrorRequestMapper(
+    private val context: Context,
+    private val siteId: String,
+    private val sdkVersion: String = BuildConfig.SdkVersion,
+    private val osVersion: () -> String = { Build.VERSION.RELEASE },
+    private val networkType: (Context) -> NetworkType = ::checkNetworkType,
+) {
+    fun map(pending: PendingNativeError): NativeErrorRequest {
+        val nativeError = pending.error
+        val safeOsVersion = osVersion().takeIf { SAFE_OS_VERSION.matches(it) && it.length <= MAX_OS_VERSION_LENGTH }
+        val connectivity = when (networkType(context)) {
+            NetworkType.WIFI -> "wifi"
+            NetworkType.CELLULAR_3G,
+            NetworkType.CELLULAR_4G,
+            NetworkType.CELLULAR_5G,
+            NetworkType.CELLULAR_UNKNOWN -> "cellular"
+            NetworkType.NONE -> "none"
+        }
+        return NativeErrorRequest(
+            eventId = pending.eventId,
+            occurredAt = pending.occurredAt,
+            source = NativeErrorSourceRequest(
+                sdkName = "openplatform_sdk_android",
+                sdkVersion = sdkVersion,
+                hostPlatform = "android",
+                sdkTechnology = "native",
+                module = nativeError.operation.module.value,
+                operation = nativeError.operation.value,
+            ),
+            siteId = siteId,
+            error = NativeErrorDetailRequest(
+                code = nativeError.code.value,
+                category = nativeError.code.category,
+                critical = nativeError.code.critical,
+                statusCode = nativeError.statusCode?.takeIf { it in MIN_HTTP_STATUS..MAX_HTTP_STATUS },
+                requestCorrelationId = nativeError.requestCorrelationId?.takeIf {
+                    it.length in 1..MAX_CORRELATION_ID_LENGTH && SAFE_CORRELATION_ID.matches(it)
+                },
+                serviceTarget = nativeError.operation.serviceTarget,
+                diagnosticCode = nativeError.diagnostic?.value,
+            ),
+            device = NativeErrorDeviceRequest(
+                osVersion = safeOsVersion,
+                connectivity = connectivity,
+            ),
+        )
+    }
+
+    private companion object {
+        const val MAX_CORRELATION_ID_LENGTH = 128
+        const val MAX_OS_VERSION_LENGTH = 32
+        const val MIN_HTTP_STATUS = 100
+        const val MAX_HTTP_STATUS = 599
+        val SAFE_CORRELATION_ID = Regex("[A-Za-z0-9._:-]+")
+        val SAFE_OS_VERSION = Regex("[0-9A-Za-z._+\\-]+")
+    }
+}

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/remote/models/request/NativeErrorRequest.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/remote/models/request/NativeErrorRequest.kt
@@ -1,0 +1,36 @@
+package com.mercadopago.sdk.android.analytics.data.remote.models.request
+
+import com.google.gson.annotations.SerializedName
+
+internal data class NativeErrorRequest(
+    @SerializedName("event_id") val eventId: String,
+    @SerializedName("occurred_at") val occurredAt: String,
+    @SerializedName("source") val source: NativeErrorSourceRequest,
+    @SerializedName("site_id") val siteId: String,
+    @SerializedName("error") val error: NativeErrorDetailRequest,
+    @SerializedName("device") val device: NativeErrorDeviceRequest?,
+)
+
+internal data class NativeErrorSourceRequest(
+    @SerializedName("sdk_name") val sdkName: String,
+    @SerializedName("sdk_version") val sdkVersion: String,
+    @SerializedName("host_platform") val hostPlatform: String,
+    @SerializedName("sdk_technology") val sdkTechnology: String,
+    @SerializedName("module") val module: String,
+    @SerializedName("operation") val operation: String,
+)
+
+internal data class NativeErrorDetailRequest(
+    @SerializedName("code") val code: String,
+    @SerializedName("category") val category: String,
+    @SerializedName("critical") val critical: Boolean,
+    @SerializedName("status_code") val statusCode: Int?,
+    @SerializedName("request_correlation_id") val requestCorrelationId: String?,
+    @SerializedName("service_target") val serviceTarget: String?,
+    @SerializedName("diagnostic_code") val diagnosticCode: String?,
+)
+
+internal data class NativeErrorDeviceRequest(
+    @SerializedName("os_version") val osVersion: String?,
+    @SerializedName("connectivity") val connectivity: String?,
+)

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/remote/service/NativeErrorService.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/remote/service/NativeErrorService.kt
@@ -1,0 +1,11 @@
+package com.mercadopago.sdk.android.analytics.data.remote.service
+
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorRequest
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+internal interface NativeErrorService {
+    @POST("/op-frontend-metrics/v2/error-metric")
+    suspend fun report(@Body request: NativeErrorRequest): Response<Unit>
+}

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/repository/NativeErrorRepositoryImpl.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/repository/NativeErrorRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.mercadopago.sdk.android.analytics.data.repository
+
+import com.mercadopago.sdk.android.analytics.data.datasource.remote.NativeErrorRemoteDataSource
+import com.mercadopago.sdk.android.analytics.data.remote.mapper.NativeErrorRequestMapper
+import com.mercadopago.sdk.android.analytics.domain.models.PendingNativeError
+import com.mercadopago.sdk.android.analytics.domain.repository.NativeErrorRepository
+
+internal class NativeErrorRepositoryImpl(
+    private val mapper: NativeErrorRequestMapper,
+    private val remoteDataSource: NativeErrorRemoteDataSource,
+) : NativeErrorRepository {
+    override suspend fun report(error: PendingNativeError): Boolean =
+        remoteDataSource.report(mapper.map(error))
+}

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/di/AnalyticsModulesProvider.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/di/AnalyticsModulesProvider.kt
@@ -10,6 +10,7 @@ import org.koin.core.module.Module
 internal class AnalyticsModulesProvider(
     val context: Context,
     val getSiteIdFlow: Flow<String>,
+    val nativeSiteId: String,
 ) : CoreKoinModuleProvider {
 
     override val koinApp: Koin = CoreKoinFactory.createKoinApp(
@@ -22,5 +23,6 @@ internal class AnalyticsModulesProvider(
         provideDataSourceModule(),
         provideRepositoryModule(getSiteIdFlow),
         provideUseCaseModule(),
+        provideReporterModule(nativeSiteId),
     )
 }

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/di/ReporterModule.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/di/ReporterModule.kt
@@ -1,0 +1,66 @@
+package com.mercadopago.sdk.android.analytics.di
+
+import com.google.gson.GsonBuilder
+import com.mercadopago.sdk.android.analytics.data.datasource.remote.NativeErrorRemoteDataSource
+import com.mercadopago.sdk.android.analytics.data.datasource.remote.NativeErrorRemoteDataSourceImpl
+import com.mercadopago.sdk.android.analytics.data.remote.mapper.NativeErrorRequestMapper
+import com.mercadopago.sdk.android.analytics.data.remote.service.NativeErrorService
+import com.mercadopago.sdk.android.analytics.data.repository.NativeErrorRepositoryImpl
+import com.mercadopago.sdk.android.analytics.domain.interactor.MPErrorReporter
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorDeliveryMode
+import com.mercadopago.sdk.android.analytics.domain.repository.NativeErrorRepository
+import com.mercadopago.sdk.android.analytics.domain.usecase.ReportNativeErrorUseCase
+import com.mercadopago.sdk.android.core.BuildConfig
+import okhttp3.OkHttpClient
+import org.koin.android.ext.koin.androidApplication
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+
+internal const val NATIVE_ERROR_GSON = "native_error_gson"
+internal const val NATIVE_ERROR_HTTP_CLIENT = "native_error_http_client"
+internal const val NATIVE_ERROR_RETROFIT = "native_error_retrofit"
+private const val TRANSPORT_TIMEOUT_SECONDS = 2L
+private const val CALL_TIMEOUT_SECONDS = 3L
+
+internal fun provideReporterModule(nativeSiteId: String) = module {
+    single(named(NATIVE_ERROR_GSON)) { GsonBuilder().create() }
+    single(named(NATIVE_ERROR_HTTP_CLIENT)) {
+        OkHttpClient.Builder()
+            .connectTimeout(TRANSPORT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(TRANSPORT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .writeTimeout(TRANSPORT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .callTimeout(CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .retryOnConnectionFailure(false)
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .build()
+    }
+    single(named(NATIVE_ERROR_RETROFIT)) {
+        Retrofit.Builder()
+            .baseUrl(BuildConfig.MERCADO_PAGO_API_URL)
+            .client(get(named(NATIVE_ERROR_HTTP_CLIENT)))
+            .addConverterFactory(GsonConverterFactory.create(get(named(NATIVE_ERROR_GSON))))
+            .build()
+    }
+    single {
+        get<Retrofit>(named(NATIVE_ERROR_RETROFIT)).create(NativeErrorService::class.java)
+    }
+    factory { NativeErrorRequestMapper(androidApplication(), nativeSiteId) }
+    factory<NativeErrorRemoteDataSource> { NativeErrorRemoteDataSourceImpl(get()) }
+    factory<NativeErrorRepository> { NativeErrorRepositoryImpl(get(), get()) }
+    factory { ReportNativeErrorUseCase(get()) }
+    single {
+        NativeErrorDeliveryMode.from(
+            com.mercadopago.sdk.android.analytics.BuildConfig.NATIVE_ERROR_DELIVERY_MODE
+        )
+    }
+    single {
+        MPErrorReporter(
+            reportNativeError = get(),
+            deliveryMode = get(),
+        )
+    }
+}

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/interactor/MPAnalytics.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/interactor/MPAnalytics.kt
@@ -6,6 +6,7 @@ import androidx.annotation.RestrictTo
 import com.mercadopago.sdk.android.analytics.di.AnalyticsModulesProvider
 import com.mercadopago.sdk.android.analytics.domain.exception.AnalyticsInitializationException
 import com.mercadopago.sdk.android.analytics.domain.models.Metric
+import com.mercadopago.sdk.android.analytics.domain.models.NativeError
 import com.mercadopago.sdk.android.analytics.domain.usecase.TrackMetricUseCase
 import com.mercadopago.sdk.android.core.utils.isDebugApp
 import com.mercadopago.sdk.android.core.utils.isSameLibraryGroup
@@ -35,6 +36,7 @@ const val MP_ANALYTICS_TAG = "MPAnalytics"
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class MPAnalytics internal constructor(
     private val koin: Koin,
+    private val errorReporter: MPErrorReporter,
 ) {
 
     /**
@@ -63,20 +65,35 @@ class MPAnalytics internal constructor(
         /** Call this method to initialize the analytics instance.
          * @param context application context.
          * @param getSiteIdFlow a flow that emits the current siteId.
+         * @param nativeSiteId synchronously configured site used by native error reports.
          * */
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Synchronized
         fun initialize(
             context: Context,
             getSiteIdFlow: Flow<String>,
+            nativeSiteId: String,
         ) {
+            clearInstance()
             val modulesProvider = AnalyticsModulesProvider(
                 getSiteIdFlow = getSiteIdFlow,
                 context = context,
+                nativeSiteId = nativeSiteId,
             )
             instance = MPAnalytics(
                 koin = modulesProvider.koinApp,
+                errorReporter = modulesProvider.koinApp.get(),
             )
+        }
+
+        /** Closes the reporter and dependency graph, then clears the analytics instance. */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Synchronized
+        fun clearInstance() {
+            val previous = instance
+            instance = null
+            previous?.errorReporter?.close()
+            previous?.koin?.close()
         }
     }
 
@@ -96,6 +113,26 @@ class MPAnalytics internal constructor(
                         Log.e(MP_ANALYTICS_TAG, "Error while tracking metric", it)
                     }
                 }.firstOrNull()
+        }
+    }
+
+    /**
+     * Offers a classified error to the bounded reporter and correlates its legacy metric.
+     * Reporting failures are contained and never replace a product result.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun trackError(
+        error: NativeError,
+        legacyMetricFactory: (String) -> Metric,
+    ) {
+        try {
+            errorReporter.track(
+                error = error,
+                legacyMetricFactory = legacyMetricFactory,
+                legacyMetricSender = ::trackMetric,
+            )
+        } catch (_: Throwable) {
+            // Observability must never replace an SDK product result.
         }
     }
 }

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/interactor/MPErrorReporter.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/interactor/MPErrorReporter.kt
@@ -1,0 +1,96 @@
+package com.mercadopago.sdk.android.analytics.domain.interactor
+
+import com.mercadopago.sdk.android.analytics.domain.models.Metric
+import com.mercadopago.sdk.android.analytics.domain.models.NativeError
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorDeliveryMode
+import com.mercadopago.sdk.android.analytics.domain.models.PendingNativeError
+import com.mercadopago.sdk.android.analytics.domain.usecase.ReportNativeErrorUseCase
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import java.util.UUID
+
+@Suppress("DEPRECATION", "DEPRECATION_ERROR")
+internal class MPErrorReporter(
+    private val reportNativeError: ReportNativeErrorUseCase,
+    private val deliveryMode: NativeErrorDeliveryMode,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val eventIdProvider: () -> String = { UUID.randomUUID().toString() },
+    private val timestampProvider: () -> String = ::utcTimestamp,
+) {
+    private val channel = Channel<PendingNativeError>(REPORT_BUFFER_CAPACITY)
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    init {
+        scope.launch {
+            for (pendingError in channel) {
+                try {
+                    reportNativeError(pendingError)
+                } catch (cancellation: CancellationException) {
+                    throw cancellation
+                } catch (_: Throwable) {
+                    // Best effort by design: transport failures never escape the worker.
+                }
+            }
+        }
+    }
+
+    fun track(
+        error: NativeError,
+        legacyMetricFactory: (String) -> Metric,
+        legacyMetricSender: (Metric) -> Unit,
+    ) {
+        try {
+            val eventId = eventIdProvider()
+            val pending = PendingNativeError(
+                eventId = eventId,
+                occurredAt = timestampProvider(),
+                error = error,
+            )
+            if (deliveryMode != NativeErrorDeliveryMode.OBSERVABILITY_ONLY) {
+                try {
+                    legacyMetricSender(legacyMetricFactory(eventId))
+                } catch (_: Throwable) {
+                    // Legacy analytics is isolated from v2 delivery.
+                }
+            }
+            if (deliveryMode != NativeErrorDeliveryMode.MELIDATA_ONLY) {
+                try {
+                    channel.offer(pending)
+                } catch (_: Throwable) {
+                    // A closed/full reporter drops newest without changing public behavior.
+                }
+            }
+        } catch (_: Throwable) {
+            // ID/time creation and any injected test implementation remain non-throwing.
+        }
+    }
+
+    fun close() {
+        channel.close()
+        scope.cancel()
+    }
+
+    private companion object {
+        const val REPORT_BUFFER_CAPACITY = 64
+        val UTC_TIMESTAMP_FORMATTER = object : ThreadLocal<SimpleDateFormat>() {
+            override fun initialValue(): SimpleDateFormat = SimpleDateFormat(
+                "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+                Locale.US,
+            ).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }
+        }
+
+        fun utcTimestamp(): String = checkNotNull(UTC_TIMESTAMP_FORMATTER.get()).format(Date())
+    }
+}

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeError.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeError.kt
@@ -1,0 +1,87 @@
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicProperty")
+
+package com.mercadopago.sdk.android.analytics.domain.models
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class NativeErrorModule(val value: String) {
+    CORE_METHODS("core_methods"),
+    CHECKOUT("checkout"),
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class NativeErrorOperation(
+    val value: String,
+    val module: NativeErrorModule,
+    val serviceTarget: String?,
+) {
+    IDENTIFICATION_TYPES("identification_types", NativeErrorModule.CORE_METHODS, "identification_types"),
+    INSTALLMENTS("installments", NativeErrorModule.CORE_METHODS, "installments"),
+    PAYMENT_METHODS("payment_methods", NativeErrorModule.CORE_METHODS, "payment_methods"),
+    ISSUERS("issuers", NativeErrorModule.CORE_METHODS, "issuers"),
+    CARD_TOKENIZATION("card_tokenization", NativeErrorModule.CORE_METHODS, null),
+    CARD_FORM_INITIALIZATION("card_form_initialization", NativeErrorModule.CHECKOUT, "checkout_initialization"),
+    CARD_FORM_SUBMISSION("card_form_submission", NativeErrorModule.CHECKOUT, null),
+    CARD_FORM_CANCELLATION("card_form_cancellation", NativeErrorModule.CHECKOUT, null),
+    INSTALLMENTS_CANCELLATION("installments_cancellation", NativeErrorModule.CHECKOUT, null),
+    ORDER_SUBMISSION("order_submission", NativeErrorModule.CHECKOUT, "orders"),
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class NativeErrorCode(
+    val value: String,
+    val category: String,
+    val critical: Boolean,
+) {
+    USER_CANCELLED("user_cancelled", "cancellation", false),
+    REQUEST_CANCELLED("request_cancelled", "cancellation", false),
+    INPUT_VALIDATION_FAILED("input_validation_failed", "input_validation", false),
+    CONNECTION_UNAVAILABLE("connection_unavailable", "network", false),
+    REQUEST_TIMEOUT("request_timeout", "service", true),
+    UPSTREAM_REJECTED("upstream_rejected", "service", true),
+    RESPONSE_CONTRACT_INVALID("response_contract_invalid", "integration", true),
+    SDK_CONFIGURATION_INVALID("sdk_configuration_invalid", "integration", true),
+    OPERATION_FAILED("operation_failed", "unknown", true),
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class NativeErrorDiagnostic(val value: String) {
+    CANCELLED("cancelled"),
+    VALIDATION("validation"),
+    OFFLINE("offline"),
+    DNS_FAILURE("dns_failure"),
+    CONNECTION_LOST("connection_lost"),
+    TIMEOUT("timeout"),
+    EMPTY_BODY("empty_body"),
+    DECODE_FAILURE("decode_failure"),
+    INVALID_URL("invalid_url"),
+    HTTP_UNAUTHORIZED("http_unauthorized"),
+    HTTP_FORBIDDEN("http_forbidden"),
+}
+
+internal enum class NativeErrorDeliveryMode {
+    MELIDATA_ONLY,
+    DUAL_WRITE,
+    OBSERVABILITY_ONLY;
+
+    companion object {
+        fun from(value: String): NativeErrorDeliveryMode =
+            values().firstOrNull { it.name == value } ?: MELIDATA_ONLY
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class NativeError(
+    val operation: NativeErrorOperation,
+    val code: NativeErrorCode,
+    val statusCode: Int? = null,
+    val requestCorrelationId: String? = null,
+    val diagnostic: NativeErrorDiagnostic? = null,
+)
+
+internal data class PendingNativeError(
+    val eventId: String,
+    val occurredAt: String,
+    val error: NativeError,
+)

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/repository/NativeErrorRepository.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/repository/NativeErrorRepository.kt
@@ -1,0 +1,7 @@
+package com.mercadopago.sdk.android.analytics.domain.repository
+
+import com.mercadopago.sdk.android.analytics.domain.models.PendingNativeError
+
+internal interface NativeErrorRepository {
+    suspend fun report(error: PendingNativeError): Boolean
+}

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/usecase/ReportNativeErrorUseCase.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/usecase/ReportNativeErrorUseCase.kt
@@ -1,0 +1,10 @@
+package com.mercadopago.sdk.android.analytics.domain.usecase
+
+import com.mercadopago.sdk.android.analytics.domain.models.PendingNativeError
+import com.mercadopago.sdk.android.analytics.domain.repository.NativeErrorRepository
+
+internal class ReportNativeErrorUseCase(
+    private val repository: NativeErrorRepository,
+) {
+    suspend operator fun invoke(error: PendingNativeError): Boolean = repository.report(error)
+}

--- a/analytics/src/test/java/com/mercadopago/sdk/android/analytics/MPAnalyticsTest.kt
+++ b/analytics/src/test/java/com/mercadopago/sdk/android/analytics/MPAnalyticsTest.kt
@@ -3,6 +3,10 @@ package com.mercadopago.sdk.android.analytics
 import android.content.Context
 import android.util.Log
 import com.mercadopago.sdk.android.analytics.domain.interactor.MPAnalytics
+import com.mercadopago.sdk.android.analytics.domain.interactor.MPErrorReporter
+import com.mercadopago.sdk.android.analytics.domain.models.NativeError
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorCode
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorOperation
 import com.mercadopago.sdk.android.analytics.domain.usecase.TrackMetricUseCase
 import com.mercadopago.sdk.android.core.di.CoreKoinFactory
 import com.mercadopago.sdk.android.core.utils.isSameLibraryGroup
@@ -24,6 +28,7 @@ internal class MPAnalyticsTest {
     private val context = mockk<Context>(relaxed = true)
     private val koin = mockk<Koin>(relaxed = true)
     private val trackMetricUseCase = mockk<TrackMetricUseCase>(relaxed = true)
+    private val errorReporter = mockk<MPErrorReporter>(relaxed = true)
 
     @Before
     fun setup() {
@@ -36,6 +41,7 @@ internal class MPAnalyticsTest {
         every {
             koin.get<TrackMetricUseCase>()
         } returns trackMetricUseCase
+        every { koin.get<MPErrorReporter>() } returns errorReporter
     }
 
     @Test
@@ -47,6 +53,7 @@ internal class MPAnalyticsTest {
         MPAnalytics.initialize(
             context = context,
             getSiteIdFlow = getSiteIdFlow,
+            nativeSiteId = "MLA",
         )
 
         // Then
@@ -63,6 +70,7 @@ internal class MPAnalyticsTest {
         MPAnalytics.initialize(
             context = context,
             getSiteIdFlow = getSiteIdFlow,
+            nativeSiteId = "MLA",
         )
         MPAnalytics.getInstance().trackMetric(metric)
 
@@ -93,6 +101,7 @@ internal class MPAnalyticsTest {
         MPAnalytics.initialize(
             context = context,
             getSiteIdFlow = getSiteIdFlow,
+            nativeSiteId = "MLA",
         )
         MPAnalytics.getInstance().trackMetric(metric)
 
@@ -101,5 +110,27 @@ internal class MPAnalyticsTest {
         verify {
             trackMetricUseCase(metric)
         }
+    }
+
+    @Test
+    fun `track error delegates to the bounded reporter`() {
+        val error = NativeError(
+            operation = NativeErrorOperation.ISSUERS,
+            code = NativeErrorCode.REQUEST_TIMEOUT,
+        )
+        MPAnalytics.initialize(context, flowOf("MLA"), "MLA")
+
+        MPAnalytics.getInstance().trackError(error) { mockMetric() }
+
+        verify(exactly = 1) { errorReporter.track(error, any(), any()) }
+    }
+
+    @Test
+    fun `reinitialization closes the previous reporter and Koin graph`() {
+        MPAnalytics.initialize(context, flowOf("MLA"), "MLA")
+        MPAnalytics.initialize(context, flowOf("MLB"), "MLB")
+
+        verify(atLeast = 1) { errorReporter.close() }
+        verify(atLeast = 1) { koin.close() }
     }
 }

--- a/analytics/src/test/java/com/mercadopago/sdk/android/analytics/data/datasource/remote/NativeErrorNetworkIntegrationTest.kt
+++ b/analytics/src/test/java/com/mercadopago/sdk/android/analytics/data/datasource/remote/NativeErrorNetworkIntegrationTest.kt
@@ -1,0 +1,119 @@
+package com.mercadopago.sdk.android.analytics.data.datasource.remote
+
+import com.google.gson.GsonBuilder
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorDetailRequest
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorRequest
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorSourceRequest
+import com.mercadopago.sdk.android.analytics.data.remote.service.NativeErrorService
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class NativeErrorNetworkIntegrationTest {
+    private lateinit var server: MockWebServer
+    private lateinit var dataSource: NativeErrorRemoteDataSource
+
+    @Before
+    fun setup() {
+        server = MockWebServer()
+        server.start()
+        val client = OkHttpClient.Builder()
+            .connectTimeout(2, TimeUnit.SECONDS)
+            .readTimeout(2, TimeUnit.SECONDS)
+            .writeTimeout(2, TimeUnit.SECONDS)
+            .callTimeout(3, TimeUnit.SECONDS)
+            .retryOnConnectionFailure(false)
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .build()
+        val service = Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .client(client)
+            .addConverterFactory(GsonConverterFactory.create(GsonBuilder().create()))
+            .build()
+            .create(NativeErrorService::class.java)
+        dataSource = NativeErrorRemoteDataSourceImpl(service)
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `only 202 is accepted and request has no credential material`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(202))
+
+        assertTrue(dataSource.report(request()))
+        val recorded = server.takeRequest()
+        assertEquals("/op-frontend-metrics/v2/error-metric", recorded.path)
+        assertEquals("POST", recorded.method)
+        assertNull(recorded.getHeader("Authorization"))
+        assertNull(recorded.getHeader("Cookie"))
+        assertFalse(recorded.path.orEmpty().contains("public_key"))
+        assertFalse(recorded.body.readUtf8().contains("public_key"))
+    }
+
+    @Test
+    fun `non 202 redirect is rejected without retry`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(302).setHeader("Location", "/other"))
+
+        assertFalse(dataSource.report(request()))
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `every non accepted status is contained without retry`() = runBlocking {
+        listOf(200, 400, 401, 422, 429, 500, 503).forEach { status ->
+            server.enqueue(MockResponse().setResponseCode(status))
+
+            assertFalse(dataSource.report(request()), status.toString())
+        }
+
+        assertEquals(7, server.requestCount)
+    }
+
+    @Test
+    fun `transport disconnect is contained without retry`() = runBlocking {
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+
+        assertFalse(dataSource.report(request()))
+        assertEquals(1, server.requestCount)
+    }
+
+    private fun request() = NativeErrorRequest(
+        eventId = "3f6fd694-4ba8-4f45-ae7c-871c4698aace",
+        occurredAt = "2026-08-27T12:00:00.000Z",
+        source = NativeErrorSourceRequest(
+            sdkName = "openplatform_sdk_android",
+            sdkVersion = "1.0.0",
+            hostPlatform = "android",
+            sdkTechnology = "native",
+            module = "core_methods",
+            operation = "issuers",
+        ),
+        siteId = "MLA",
+        error = NativeErrorDetailRequest(
+            code = "request_timeout",
+            category = "service",
+            critical = true,
+            statusCode = 504,
+            requestCorrelationId = null,
+            serviceTarget = "issuers",
+            diagnosticCode = "timeout",
+        ),
+        device = null,
+    )
+}

--- a/analytics/src/test/java/com/mercadopago/sdk/android/analytics/data/remote/mapper/NativeErrorRequestMapperTest.kt
+++ b/analytics/src/test/java/com/mercadopago/sdk/android/analytics/data/remote/mapper/NativeErrorRequestMapperTest.kt
@@ -1,0 +1,142 @@
+package com.mercadopago.sdk.android.analytics.data.remote.mapper
+
+import android.content.Context
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonParser
+import com.mercadopago.sdk.android.analytics.domain.models.NativeError
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorCode
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorDiagnostic
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorOperation
+import com.mercadopago.sdk.android.analytics.domain.models.PendingNativeError
+import com.mercadopago.sdk.android.core.utils.NetworkType
+import io.mockk.mockk
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+internal class NativeErrorRequestMapperTest {
+    private val context = mockk<Context>(relaxed = true)
+
+    @Test
+    fun `maps the fixed android source and derived catalog values`() {
+        val mapper = NativeErrorRequestMapper(
+            context = context,
+            siteId = "MLB",
+            sdkVersion = "1.2.3",
+            osVersion = { "14" },
+            networkType = { NetworkType.WIFI },
+        )
+
+        val request = mapper.map(
+            PendingNativeError(
+                eventId = "3f6fd694-4ba8-4f45-ae7c-871c4698aace",
+                occurredAt = "2026-08-27T12:00:00.000Z",
+                error = NativeError(
+                    operation = NativeErrorOperation.ISSUERS,
+                    code = NativeErrorCode.REQUEST_TIMEOUT,
+                    statusCode = 504,
+                    requestCorrelationId = "request:123",
+                    diagnostic = NativeErrorDiagnostic.TIMEOUT,
+                ),
+            )
+        )
+
+        assertEquals("openplatform_sdk_android", request.source.sdkName)
+        assertEquals("android", request.source.hostPlatform)
+        assertEquals("native", request.source.sdkTechnology)
+        assertEquals("core_methods", request.source.module)
+        assertEquals("issuers", request.source.operation)
+        assertEquals("request_timeout", request.error.code)
+        assertEquals("service", request.error.category)
+        assertEquals(true, request.error.critical)
+        assertEquals("issuers", request.error.serviceTarget)
+        assertEquals("wifi", request.device?.connectivity)
+    }
+
+    @Test
+    fun `omits invalid optional values and Gson never serializes null fields`() {
+        val mapper = NativeErrorRequestMapper(
+            context = context,
+            siteId = "MLA",
+            sdkVersion = "1.0.0",
+            osVersion = { "invalid value" },
+            networkType = { NetworkType.NONE },
+        )
+        val request = mapper.map(
+            PendingNativeError(
+                eventId = "3f6fd694-4ba8-4f45-ae7c-871c4698aace",
+                occurredAt = "2026-08-27T12:00:00.000Z",
+                error = NativeError(
+                    operation = NativeErrorOperation.CARD_TOKENIZATION,
+                    code = NativeErrorCode.OPERATION_FAILED,
+                    statusCode = 99,
+                    requestCorrelationId = "not safe!",
+                ),
+            )
+        )
+
+        assertNull(request.error.statusCode)
+        assertNull(request.error.requestCorrelationId)
+        assertNull(request.error.serviceTarget)
+        assertNull(request.device?.osVersion)
+        val json = GsonBuilder().create().toJson(request)
+        assertFalse(json.contains("status_code"))
+        assertFalse(json.contains("request_correlation_id"))
+        assertFalse(json.contains("service_target"))
+        FORBIDDEN_JSON_KEYS.forEach { key ->
+            assertFalse(json.contains("\"$key\""), "Forbidden key was serialized: $key")
+        }
+    }
+
+    @Test
+    fun `android checkout request matches the shared contract fixture`() {
+        val mapper = NativeErrorRequestMapper(
+            context = context,
+            siteId = "MLB",
+            sdkVersion = "1.2.3",
+            osVersion = { "14" },
+            networkType = { NetworkType.WIFI },
+        )
+        val request = mapper.map(
+            PendingNativeError(
+                eventId = "3f6fd694-4ba8-4f45-ae7c-871c4698aace",
+                occurredAt = "2026-08-27T12:00:00.000Z",
+                error = NativeError(
+                    operation = NativeErrorOperation.ORDER_SUBMISSION,
+                    code = NativeErrorCode.UPSTREAM_REJECTED,
+                    statusCode = 503,
+                ),
+            ),
+        )
+
+        val actual = JsonParser().parse(GsonBuilder().create().toJson(request))
+        val expectedJson = checkNotNull(javaClass.getResource("/fixtures/native_error_android_checkout.json"))
+            .readText()
+        assertEquals(JsonParser().parse(expectedJson), actual)
+    }
+
+    private companion object {
+        val FORBIDDEN_JSON_KEYS = setOf(
+            "authorization",
+            "cookie",
+            "public_key",
+            "access_token",
+            "pan",
+            "bin",
+            "cvv",
+            "payer",
+            "email",
+            "order_id",
+            "payment_id",
+            "package",
+            "device_id",
+            "url",
+            "request_body",
+            "response_body",
+            "raw_error",
+            "message",
+            "detail",
+        )
+    }
+}

--- a/analytics/src/test/java/com/mercadopago/sdk/android/analytics/di/AnalyticsModulesProviderTest.kt
+++ b/analytics/src/test/java/com/mercadopago/sdk/android/analytics/di/AnalyticsModulesProviderTest.kt
@@ -1,12 +1,14 @@
 package com.mercadopago.sdk.android.analytics.di
 
 import android.app.Application
+import android.content.Context
 import android.content.pm.ApplicationInfo
 import com.mercadopago.sdk.android.core.di.CoreKoinFactory
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import org.junit.Test
 import org.koin.android.ext.koin.androidContext
@@ -34,6 +36,7 @@ internal class AnalyticsModulesProviderTest {
         val modulesProvider = AnalyticsModulesProvider(
             context = context,
             getSiteIdFlow = mockk<Flow<String>>(),
+            nativeSiteId = "MLA",
         )
 
         // When
@@ -46,7 +49,15 @@ internal class AnalyticsModulesProviderTest {
         }
 
         // Then
-        module.verify()
+        module.verify(
+            extraTypes = listOf(
+                CoroutineDispatcher::class,
+                Context::class,
+                String::class,
+                Function0::class,
+                Function1::class,
+            )
+        )
         koin.checkModules()
     }
 }

--- a/analytics/src/test/java/com/mercadopago/sdk/android/analytics/domain/interactor/MPErrorReporterTest.kt
+++ b/analytics/src/test/java/com/mercadopago/sdk/android/analytics/domain/interactor/MPErrorReporterTest.kt
@@ -1,0 +1,181 @@
+package com.mercadopago.sdk.android.analytics.domain.interactor
+
+import com.mercadopago.sdk.android.analytics.domain.models.EventData
+import com.mercadopago.sdk.android.analytics.domain.models.Metric
+import com.mercadopago.sdk.android.analytics.domain.models.NativeError
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorCode
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorDeliveryMode
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorOperation
+import com.mercadopago.sdk.android.analytics.domain.models.TrackType
+import com.mercadopago.sdk.android.analytics.domain.repository.NativeErrorRepository
+import com.mercadopago.sdk.android.analytics.domain.usecase.ReportNativeErrorUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class MPErrorReporterTest {
+    private val repository = mockk<NativeErrorRepository>()
+    private val useCase = ReportNativeErrorUseCase(repository)
+    private val scheduler = TestCoroutineScheduler()
+    private val dispatcher = StandardTestDispatcher(scheduler)
+    private val error = NativeError(
+        operation = NativeErrorOperation.ISSUERS,
+        code = NativeErrorCode.REQUEST_TIMEOUT,
+    )
+
+    @Test
+    fun `dual write gives one deterministic id to both deliveries`() {
+        coEvery { repository.report(any()) } returns true
+        val legacyIds = mutableListOf<String>()
+        val reporter = reporter(NativeErrorDeliveryMode.DUAL_WRITE)
+
+        reporter.track(
+            error = error,
+            legacyMetricFactory = { id ->
+                legacyIds += id
+            metric()
+            },
+            legacyMetricSender = {},
+        )
+        scheduler.advanceUntilIdle()
+
+        assertEquals(listOf(EVENT_ID), legacyIds)
+        coVerify(exactly = 1) {
+            repository.report(match { it.eventId == EVENT_ID && it.occurredAt == TIMESTAMP })
+        }
+        reporter.close()
+    }
+
+    @Test
+    fun `melidata only never queues v2 and observability only never builds legacy`() {
+        coEvery { repository.report(any()) } returns true
+        var legacyCount = 0
+        reporter(NativeErrorDeliveryMode.MELIDATA_ONLY).apply {
+            track(error, {
+                legacyCount++
+            metric()
+            }, {})
+            scheduler.advanceUntilIdle()
+            close()
+        }
+        reporter(NativeErrorDeliveryMode.OBSERVABILITY_ONLY).apply {
+            track(error, {
+                legacyCount++
+            metric()
+            }, {})
+            scheduler.advanceUntilIdle()
+            close()
+        }
+
+        assertEquals(1, legacyCount)
+        coVerify(exactly = 1) { repository.report(any()) }
+    }
+
+    @Test
+    fun `65th pending error is dropped newest`() {
+        coEvery { repository.report(any()) } returns true
+        val pausedScheduler = TestCoroutineScheduler()
+        val pausedDispatcher = StandardTestDispatcher(pausedScheduler)
+        val reporter = MPErrorReporter(
+            reportNativeError = useCase,
+            deliveryMode = NativeErrorDeliveryMode.DUAL_WRITE,
+            dispatcher = pausedDispatcher,
+            eventIdProvider = incrementingIds(),
+            timestampProvider = { TIMESTAMP },
+        )
+
+        repeat(65) { reporter.track(error, { metric() }, {}) }
+        pausedScheduler.advanceUntilIdle()
+
+        coVerify(exactly = 64) { repository.report(any()) }
+        coVerify(exactly = 0) { repository.report(match { it.eventId == "event-65" }) }
+        reporter.close()
+    }
+
+    @Test
+    fun `legacy and v2 failures are isolated and close rejects new work`() {
+        coEvery { repository.report(any()) } throws IllegalStateException("transport")
+        val reporter = reporter(NativeErrorDeliveryMode.DUAL_WRITE)
+
+        reporter.track(error, { throw IllegalStateException("legacy") }, {})
+        scheduler.advanceUntilIdle()
+        reporter.close()
+        reporter.track(error, { metric() }, { throw IllegalStateException("closed") })
+        scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.report(any()) }
+    }
+
+    @Test
+    fun `worker cancellation is not converted into a delivery failure`() {
+        coEvery { repository.report(any()) } throws CancellationException("stop")
+        val reporter = reporter(NativeErrorDeliveryMode.OBSERVABILITY_ONLY)
+
+        reporter.track(error, { metric() }, {})
+        reporter.track(error, { metric() }, {})
+        scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.report(any()) }
+        reporter.close()
+    }
+
+    @Test
+    fun `caller path p95 stays below one millisecond under queue pressure`() {
+        coEvery { repository.report(any()) } returns true
+        val reporter = MPErrorReporter(
+            reportNativeError = useCase,
+            deliveryMode = NativeErrorDeliveryMode.OBSERVABILITY_ONLY,
+            dispatcher = StandardTestDispatcher(TestCoroutineScheduler()),
+        )
+
+        repeat(PERFORMANCE_WARMUP_ITERATIONS) {
+            reporter.track(error, { metric() }, {})
+        }
+        val samples = List(PERFORMANCE_SAMPLE_COUNT) {
+            val startedAt = System.nanoTime()
+            reporter.track(error, { metric() }, {})
+            System.nanoTime() - startedAt
+        }.sorted()
+        val p95Nanos = samples[(samples.size * 95 / 100) - 1]
+
+        assertTrue(
+            p95Nanos < CALLER_PATH_P95_LIMIT_NANOS,
+            "Expected p95 below 1ms but was ${p95Nanos / NANOS_PER_MILLISECOND.toDouble()}ms",
+        )
+        reporter.close()
+    }
+
+    private fun reporter(mode: NativeErrorDeliveryMode) = MPErrorReporter(
+        reportNativeError = useCase,
+        deliveryMode = mode,
+        dispatcher = dispatcher,
+        eventIdProvider = { EVENT_ID },
+        timestampProvider = { TIMESTAMP },
+    )
+
+    private fun incrementingIds(): () -> String {
+        var current = 0
+        return { "event-${++current}" }
+    }
+
+    private fun metric() = Metric(
+        path = "/test/error",
+        type = TrackType.EVENT,
+        data = object : EventData {},
+    )
+
+    private companion object {
+        const val EVENT_ID = "3f6fd694-4ba8-4f45-ae7c-871c4698aace"
+        const val TIMESTAMP = "2026-08-27T12:00:00.000Z"
+        const val PERFORMANCE_WARMUP_ITERATIONS = 200
+        const val PERFORMANCE_SAMPLE_COUNT = 2_000
+        const val NANOS_PER_MILLISECOND = 1_000_000L
+        const val CALLER_PATH_P95_LIMIT_NANOS = NANOS_PER_MILLISECOND
+    }
+}

--- a/analytics/src/test/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorTest.kt
+++ b/analytics/src/test/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorTest.kt
@@ -1,0 +1,30 @@
+package com.mercadopago.sdk.android.analytics.domain.models
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class NativeErrorTest {
+    @Test
+    fun `catalog derives category criticality module and service target`() {
+        assertEquals("input_validation", NativeErrorCode.INPUT_VALIDATION_FAILED.category)
+        assertFalse(NativeErrorCode.INPUT_VALIDATION_FAILED.critical)
+        assertEquals("service", NativeErrorCode.REQUEST_TIMEOUT.category)
+        assertTrue(NativeErrorCode.REQUEST_TIMEOUT.critical)
+        assertEquals(NativeErrorModule.CORE_METHODS, NativeErrorOperation.ISSUERS.module)
+        assertEquals("issuers", NativeErrorOperation.ISSUERS.serviceTarget)
+        assertNull(NativeErrorOperation.CARD_TOKENIZATION.serviceTarget)
+        assertEquals(NativeErrorModule.CHECKOUT, NativeErrorOperation.ORDER_SUBMISSION.module)
+        assertEquals("orders", NativeErrorOperation.ORDER_SUBMISSION.serviceTarget)
+    }
+
+    @Test
+    fun `unknown delivery mode fails closed to melidata only`() {
+        assertEquals(
+            NativeErrorDeliveryMode.MELIDATA_ONLY,
+            NativeErrorDeliveryMode.from("unexpected")
+        )
+    }
+}

--- a/analytics/src/test/resources/fixtures/native_error_android_checkout.json
+++ b/analytics/src/test/resources/fixtures/native_error_android_checkout.json
@@ -1,0 +1,24 @@
+{
+  "event_id": "3f6fd694-4ba8-4f45-ae7c-871c4698aace",
+  "occurred_at": "2026-08-27T12:00:00.000Z",
+  "source": {
+    "sdk_name": "openplatform_sdk_android",
+    "sdk_version": "1.2.3",
+    "host_platform": "android",
+    "sdk_technology": "native",
+    "module": "checkout",
+    "operation": "order_submission"
+  },
+  "site_id": "MLB",
+  "error": {
+    "code": "upstream_rejected",
+    "category": "service",
+    "critical": true,
+    "status_code": 503,
+    "service_target": "orders"
+  },
+  "device": {
+    "os_version": "14",
+    "connectivity": "wifi"
+  }
+}

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CardFormInitAnalytics.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CardFormInitAnalytics.kt
@@ -1,7 +1,6 @@
 package com.mercadopago.sdk.android.checkout.analytics
 
 import com.google.gson.annotations.SerializedName
-import com.mercadopago.sdk.android.analytics.domain.constants.MetricErrorData
 import com.mercadopago.sdk.android.analytics.domain.models.EventData
 import com.mercadopago.sdk.android.analytics.domain.models.Metric
 import com.mercadopago.sdk.android.analytics.domain.models.TrackType
@@ -38,10 +37,11 @@ internal fun metricCardFormInitialize(
 @KoverIgnore("in development")
 internal fun metricCardFormInitializeError(
     errorType: String,
+    observabilityEventId: String,
 ) = Metric(
     path = "$SDK_NATIVE_PATH$CHECKOUT_CARD_FORM_PATH$INITIALIZE_ERROR_PATH",
     type = TrackType.EVENT,
-    data = MetricErrorData(errorType = errorType),
+    data = CheckoutErrorEventData(errorType, observabilityEventId),
 )
 
 @KoverIgnore("in development")

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CardFormSubmitAnalytics.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CardFormSubmitAnalytics.kt
@@ -1,7 +1,6 @@
 package com.mercadopago.sdk.android.checkout.analytics
 
 import com.google.gson.annotations.SerializedName
-import com.mercadopago.sdk.android.analytics.domain.constants.MetricErrorData
 import com.mercadopago.sdk.android.analytics.domain.models.EventData
 import com.mercadopago.sdk.android.analytics.domain.models.Metric
 import com.mercadopago.sdk.android.analytics.domain.models.TrackType
@@ -33,19 +32,21 @@ internal fun metricCardFormSubmit(
 @KoverIgnore("in development")
 internal fun metricCardFormSubmitError(
     errorType: String,
+    observabilityEventId: String,
 ) = Metric(
     path = "$SDK_NATIVE_PATH$CHECKOUT_CARD_FORM_PATH$SUBMIT_ERROR_PATH",
     type = TrackType.EVENT,
-    data = MetricErrorData(errorType = errorType),
+    data = CheckoutErrorEventData(errorType, observabilityEventId),
 )
 
 @KoverIgnore("in development")
 internal fun metricCardFormUserCanceledError(
     errorType: String = "",
+    observabilityEventId: String,
 ) = Metric(
     path = "$SDK_NATIVE_PATH$CHECKOUT_CARD_FORM_PATH$USER_CANCELED_PATH",
     type = TrackType.EVENT,
-    data = MetricErrorData(errorType = errorType),
+    data = CheckoutErrorEventData(errorType, observabilityEventId),
 )
 
 @KoverIgnore("in development")

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CheckoutErrorEventData.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CheckoutErrorEventData.kt
@@ -1,0 +1,9 @@
+package com.mercadopago.sdk.android.checkout.analytics
+
+import com.google.gson.annotations.SerializedName
+import com.mercadopago.sdk.android.analytics.domain.models.EventData
+
+internal data class CheckoutErrorEventData(
+    @SerializedName("error_type") val errorType: String,
+    @SerializedName("observability_event_id") val observabilityEventId: String,
+) : EventData

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CheckoutErrorObservability.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/CheckoutErrorObservability.kt
@@ -1,0 +1,54 @@
+package com.mercadopago.sdk.android.checkout.analytics
+
+import com.mercadopago.sdk.android.analytics.domain.interactor.MPAnalytics
+import com.mercadopago.sdk.android.analytics.domain.models.Metric
+import com.mercadopago.sdk.android.analytics.domain.models.NativeError
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorCode
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorDiagnostic
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorOperation
+import com.mercadopago.sdk.android.checkout.domain.model.ObservedCheckoutError
+
+internal class CheckoutErrorObservability(
+    private val analyticsProvider: () -> MPAnalytics? = MPAnalytics::tryGetInstance,
+) {
+    fun track(
+        error: ObservedCheckoutError,
+        operation: NativeErrorOperation,
+        legacyMetricFactory: (String) -> Metric,
+    ) {
+        send(
+            NativeError(
+                operation = operation,
+                code = error.nativeCode,
+                statusCode = error.httpStatus,
+                diagnostic = error.diagnostic,
+            ),
+            legacyMetricFactory,
+        )
+    }
+
+    fun trackCancellation(
+        operation: NativeErrorOperation,
+        legacyMetricFactory: (String) -> Metric,
+    ) {
+        send(
+            NativeError(
+                operation = operation,
+                code = NativeErrorCode.USER_CANCELLED,
+                diagnostic = NativeErrorDiagnostic.CANCELLED,
+            ),
+            legacyMetricFactory,
+        )
+    }
+
+    private fun send(
+        error: NativeError,
+        legacyMetricFactory: (String) -> Metric,
+    ) {
+        try {
+            analyticsProvider()?.trackError(error, legacyMetricFactory)
+        } catch (_: Throwable) {
+            // Reporting cannot change Checkout callbacks or public errors.
+        }
+    }
+}

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/InstallmentsSelectionAnalytics.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/InstallmentsSelectionAnalytics.kt
@@ -1,7 +1,6 @@
 package com.mercadopago.sdk.android.checkout.analytics
 
 import com.google.gson.annotations.SerializedName
-import com.mercadopago.sdk.android.analytics.domain.constants.MetricErrorData
 import com.mercadopago.sdk.android.analytics.domain.models.EventData
 import com.mercadopago.sdk.android.analytics.domain.models.Metric
 import com.mercadopago.sdk.android.analytics.domain.models.TrackType
@@ -40,10 +39,11 @@ internal fun metricInstallmentsSubmit(
 @KoverIgnore("in development")
 internal fun metricInstallmentsUserCanceledError(
     errorType: String,
+    observabilityEventId: String,
 ) = Metric(
     path = "$SDK_NATIVE_PATH$CHECKOUT_INSTALLMENTS_PATH$USER_CANCELED_PATH",
     type = TrackType.EVENT,
-    data = MetricErrorData(errorType = errorType),
+    data = CheckoutErrorEventData(errorType, observabilityEventId),
 )
 
 @KoverIgnore("in development")

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/OrderErrorAnalytics.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/analytics/OrderErrorAnalytics.kt
@@ -12,12 +12,14 @@ private const val ERROR_PATH = "/error"
 internal fun metricOrderError(
     errorType: String,
     orderId: String,
+    observabilityEventId: String,
 ) = Metric(
     path = "$SDK_NATIVE_PATH$ORDER_PATH$ERROR_PATH",
     type = TrackType.EVENT,
     data = OrderErrorEventData(
         errorType = errorType,
         orderId = orderId,
+        observabilityEventId = observabilityEventId,
     ),
 )
 
@@ -26,4 +28,6 @@ internal data class OrderErrorEventData(
     val errorType: String,
     @SerializedName("order_id")
     val orderId: String,
+    @SerializedName("observability_event_id")
+    val observabilityEventId: String,
 ) : EventData

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/exception/ObservedCheckoutErrorFactory.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/exception/ObservedCheckoutErrorFactory.kt
@@ -1,0 +1,127 @@
+package com.mercadopago.sdk.android.checkout.domain.exception
+
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorCode
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorDiagnostic
+import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.ObservedCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.ResponseError
+import com.mercadopago.sdk.android.coremethods.domain.model.ResultError
+import com.mercadopago.sdk.android.coremethods.domain.utils.Result
+import java.util.Locale
+
+internal object ObservedCheckoutErrorFactory {
+    fun from(
+        error: ResponseError,
+        localized: ErrorLocalized,
+    ): ObservedCheckoutError {
+        val publicError = ExceptionFactory.mapRequestError(error, localized)
+        val retainedCode = error.errorCode ?: error.code
+        val status = error.httpStatus?.takeIf { it in MIN_HTTP_STATUS..MAX_HTTP_STATUS }
+        return observed(publicError, retainedCode, status, isValidation = false)
+    }
+
+    fun from(
+        error: ResultError,
+        localized: ErrorLocalized,
+    ): ObservedCheckoutError {
+        val responseError = when (error) {
+            is ResultError.Request -> ResponseError(code = error.code, message = error.message)
+            is ResultError.Validation -> ResponseError(code = null, message = error.message)
+        }
+        val publicError = ExceptionFactory.mapRequestError(responseError, localized)
+        return observed(
+            publicError = publicError,
+            retainedCode = (error as? ResultError.Request)?.code,
+            status = null,
+            isValidation = error is ResultError.Validation,
+        )
+    }
+
+    private fun observed(
+        publicError: MercadoPagoCheckoutError,
+        retainedCode: String?,
+        status: Int?,
+        isValidation: Boolean,
+    ): ObservedCheckoutError {
+        val normalizedCode = retainedCode?.uppercase(Locale.ROOT)
+        val nativeCode = classify(publicError, normalizedCode, status, isValidation)
+        val diagnostic = diagnostic(normalizedCode, status, isValidation)
+        return ObservedCheckoutError(publicError, nativeCode, status, diagnostic)
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun classify(
+        publicError: MercadoPagoCheckoutError,
+        normalizedCode: String?,
+        status: Int?,
+        isValidation: Boolean,
+    ): NativeErrorCode =
+        when {
+            publicError is MercadoPagoCheckoutError.ConfigurationError -> NativeErrorCode.SDK_CONFIGURATION_INVALID
+            normalizedCode in CONFIGURATION_CODES -> NativeErrorCode.SDK_CONFIGURATION_INVALID
+            status == HTTP_UNAUTHORIZED || status == HTTP_FORBIDDEN -> NativeErrorCode.SDK_CONFIGURATION_INVALID
+            isValidation -> NativeErrorCode.INPUT_VALIDATION_FAILED
+            normalizedCode in CONNECTION_CODES ||
+                publicError.errorCode == ErrorCode.NETWORK_CONNECTION_FAILED ->
+                NativeErrorCode.CONNECTION_UNAVAILABLE
+            normalizedCode in TIMEOUT_CODES ||
+                publicError.errorCode == ErrorCode.NETWORK_TIMEOUT ||
+                status == HTTP_REQUEST_TIMEOUT || status == HTTP_GATEWAY_TIMEOUT -> NativeErrorCode.REQUEST_TIMEOUT
+            normalizedCode == EMPTY_BODY -> NativeErrorCode.RESPONSE_CONTRACT_INVALID
+            publicError is MercadoPagoCheckoutError.UnknownError || normalizedCode in UNKNOWN_CODES ->
+                NativeErrorCode.OPERATION_FAILED
+            publicError is MercadoPagoCheckoutError.ServiceError -> NativeErrorCode.UPSTREAM_REJECTED
+            else -> NativeErrorCode.OPERATION_FAILED
+        }
+
+    private fun diagnostic(
+        normalizedCode: String?,
+        status: Int?,
+        isValidation: Boolean,
+    ): NativeErrorDiagnostic? =
+        when {
+            status == HTTP_UNAUTHORIZED -> NativeErrorDiagnostic.HTTP_UNAUTHORIZED
+            status == HTTP_FORBIDDEN -> NativeErrorDiagnostic.HTTP_FORBIDDEN
+            isValidation -> NativeErrorDiagnostic.VALIDATION
+            normalizedCode in CONNECTION_CODES -> NativeErrorDiagnostic.OFFLINE
+            normalizedCode in TIMEOUT_CODES ||
+                status == HTTP_REQUEST_TIMEOUT ||
+                status == HTTP_GATEWAY_TIMEOUT -> NativeErrorDiagnostic.TIMEOUT
+            normalizedCode == EMPTY_BODY -> NativeErrorDiagnostic.EMPTY_BODY
+            else -> null
+        }
+
+    internal fun <T> Result<T, ResponseError>.mapResponseObserved(
+        localized: ErrorLocalized,
+    ): Result<T, ObservedCheckoutError> =
+        when (this) {
+            is Result.Success -> Result.Success(data)
+            is Result.Error -> Result.Error(from(error, localized))
+        }
+
+    internal fun <T> Result<T, ResultError>.mapResultObserved(
+        localized: ErrorLocalized,
+    ): Result<T, ObservedCheckoutError> =
+        when (this) {
+            is Result.Success -> Result.Success(data)
+            is Result.Error -> Result.Error(from(error, localized))
+        }
+
+    private const val EMPTY_BODY = "EMPTY_BODY"
+    private const val MIN_HTTP_STATUS = 100
+    private const val MAX_HTTP_STATUS = 599
+    private const val HTTP_UNAUTHORIZED = 401
+    private const val HTTP_FORBIDDEN = 403
+    private const val HTTP_REQUEST_TIMEOUT = 408
+    private const val HTTP_GATEWAY_TIMEOUT = 504
+    private val CONFIGURATION_CODES = setOf("CONFIGURATION_ERROR", "INTEGRATION_ERROR")
+    private val UNKNOWN_CODES = setOf("EXCEPTION", "UNKNOWN_ERROR")
+    private val CONNECTION_CODES = setOf(
+        "NETWORK_CONNECTION_FAILED",
+        "NO_INTERNET",
+        "CONNECTION",
+        "NETWORK",
+        "UNREACHABLE",
+    )
+    private val TIMEOUT_CODES = setOf("NETWORK_TIMEOUT", "TIMEOUT")
+}

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/ObservedCheckoutError.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/model/ObservedCheckoutError.kt
@@ -1,0 +1,11 @@
+package com.mercadopago.sdk.android.checkout.domain.model
+
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorCode
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorDiagnostic
+
+internal data class ObservedCheckoutError(
+    val publicError: MercadoPagoCheckoutError,
+    val nativeCode: NativeErrorCode,
+    val httpStatus: Int? = null,
+    val diagnostic: NativeErrorDiagnostic? = null,
+)

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/usecase/InitializeCardFormUseCase.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/usecase/InitializeCardFormUseCase.kt
@@ -1,10 +1,10 @@
 package com.mercadopago.sdk.android.checkout.domain.usecase
 
 import com.mercadopago.sdk.android.checkout.domain.exception.ErrorLocalized
-import com.mercadopago.sdk.android.checkout.domain.exception.ExceptionFactory.mapError
+import com.mercadopago.sdk.android.checkout.domain.exception.ObservedCheckoutErrorFactory.mapResponseObserved
 import com.mercadopago.sdk.android.checkout.domain.extensions.withServiceRetry
 import com.mercadopago.sdk.android.checkout.domain.model.CardFormInitializationOutput
-import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.ObservedCheckoutError
 import com.mercadopago.sdk.android.checkout.domain.model.params.InitializeCardFormParams
 import com.mercadopago.sdk.android.checkout.domain.repository.CardFormRepository
 import com.mercadopago.sdk.android.coremethods.domain.utils.Result
@@ -16,7 +16,7 @@ internal class InitializeCardFormUseCase(
         orderId: String?,
         clientToken: String?,
         checkoutType: String,
-    ): Result<CardFormInitializationOutput, MercadoPagoCheckoutError> =
+    ): Result<CardFormInitializationOutput, ObservedCheckoutError> =
         withServiceRetry {
             repository.fetchInitialization(
                 InitializeCardFormParams(
@@ -25,5 +25,5 @@ internal class InitializeCardFormUseCase(
                     checkoutType = checkoutType,
                 ),
             )
-        }.mapError(ErrorLocalized.CARD_FORM_INITIALIZATION)
+        }.mapResponseObserved(ErrorLocalized.CARD_FORM_INITIALIZATION)
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/usecase/ProcessOrderUseCase.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/domain/usecase/ProcessOrderUseCase.kt
@@ -1,9 +1,9 @@
 package com.mercadopago.sdk.android.checkout.domain.usecase
 
 import com.mercadopago.sdk.android.checkout.domain.exception.ErrorLocalized
-import com.mercadopago.sdk.android.checkout.domain.exception.ExceptionFactory.mapError
+import com.mercadopago.sdk.android.checkout.domain.exception.ObservedCheckoutErrorFactory.mapResponseObserved
 import com.mercadopago.sdk.android.checkout.domain.extensions.withErrorHandling
-import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.ObservedCheckoutError
 import com.mercadopago.sdk.android.checkout.domain.model.OrderProcessOutput
 import com.mercadopago.sdk.android.checkout.domain.model.params.ProcessOrderParams
 import com.mercadopago.sdk.android.checkout.domain.repository.OrderRepository
@@ -14,8 +14,8 @@ internal class ProcessOrderUseCase(
 ) {
     suspend operator fun invoke(
         params: ProcessOrderParams,
-    ): Result<OrderProcessOutput, MercadoPagoCheckoutError> =
+    ): Result<OrderProcessOutput, ObservedCheckoutError> =
         withErrorHandling {
             repository.process(params = params)
-        }.mapError(ErrorLocalized.ORDER_PROCESS)
+        }.mapResponseObserved(ErrorLocalized.ORDER_PROCESS)
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/usecase/GenerateTokenUseCase.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/usecase/GenerateTokenUseCase.kt
@@ -1,9 +1,9 @@
 package com.mercadopago.sdk.android.checkout.presentation.usecase
 
 import com.mercadopago.sdk.android.checkout.domain.exception.ErrorLocalized
-import com.mercadopago.sdk.android.checkout.domain.exception.ExceptionFactory.mapToCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.exception.ObservedCheckoutErrorFactory.mapResultObserved
 import com.mercadopago.sdk.android.checkout.domain.extensions.withResultErrorHandling
-import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.ObservedCheckoutError
 import com.mercadopago.sdk.android.coremethods.domain.interactor.CoreMethods
 import com.mercadopago.sdk.android.coremethods.domain.interactor.coreMethods
 import com.mercadopago.sdk.android.coremethods.domain.model.BuyerIdentification
@@ -20,7 +20,7 @@ internal class GenerateTokenUseCase(
         expirationDateState: PCIFieldState,
         securityCodeState: PCIFieldState,
         buyerIdentification: BuyerIdentification,
-    ): Result<CardToken, MercadoPagoCheckoutError> =
+    ): Result<CardToken, ObservedCheckoutError> =
         withResultErrorHandling {
             coreMethods.generateCardToken(
                 cardNumberState = cardNumberState,
@@ -28,5 +28,5 @@ internal class GenerateTokenUseCase(
                 securityCodeState = securityCodeState,
                 buyerIdentification = buyerIdentification,
             )
-        }.mapToCheckoutError(ErrorLocalized.TOKENIZATION)
+        }.mapResultObserved(ErrorLocalized.TOKENIZATION)
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardFormAnalyticsTracker.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardFormAnalyticsTracker.kt
@@ -1,6 +1,8 @@
 package com.mercadopago.sdk.android.checkout.presentation.viewmodel
 
 import com.mercadopago.sdk.android.analytics.domain.interactor.MPAnalytics
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorOperation
+import com.mercadopago.sdk.android.checkout.analytics.CheckoutErrorObservability
 import com.mercadopago.sdk.android.checkout.analytics.metricCardFormDropdownSelection
 import com.mercadopago.sdk.android.checkout.analytics.metricCardFormInitializeError
 import com.mercadopago.sdk.android.checkout.analytics.metricCardFormInputValidation
@@ -12,20 +14,24 @@ import com.mercadopago.sdk.android.checkout.analytics.metricOrderSubmit
 import com.mercadopago.sdk.android.checkout.analytics.toAnalyticsString
 import com.mercadopago.sdk.android.checkout.analytics.toErrorTypeString
 import com.mercadopago.sdk.android.checkout.core.model.MPCardType
-import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.ObservedCheckoutError
 import com.mercadopago.sdk.android.checkout.presentation.model.CancelReason
 
 internal class CardFormAnalyticsTracker(
     private val isLoading: () -> Boolean,
+    private val errorObservability: CheckoutErrorObservability = CheckoutErrorObservability(),
 ) {
     private var canceled = false
 
     fun trackInitializeError(
-        error: MercadoPagoCheckoutError,
+        error: ObservedCheckoutError,
     ) {
-        MPAnalytics.tryGetInstance()?.trackMetric(
-            metricCardFormInitializeError(errorType = error.toErrorTypeString()),
-        )
+        errorObservability.track(error, NativeErrorOperation.CARD_FORM_INITIALIZATION) { eventId ->
+            metricCardFormInitializeError(
+                errorType = error.publicError.toErrorTypeString(),
+                observabilityEventId = eventId,
+            )
+        }
     }
 
     fun trackInputValidation(
@@ -76,31 +82,38 @@ internal class CardFormAnalyticsTracker(
     }
 
     fun trackSubmitError(
-        error: MercadoPagoCheckoutError,
+        error: ObservedCheckoutError,
     ) {
-        MPAnalytics.tryGetInstance()?.trackMetric(
-            metricCardFormSubmitError(errorType = error.toErrorTypeString()),
-        )
+        errorObservability.track(error, NativeErrorOperation.CARD_FORM_SUBMISSION) { eventId ->
+            metricCardFormSubmitError(
+                errorType = error.publicError.toErrorTypeString(),
+                observabilityEventId = eventId,
+            )
+        }
     }
 
     fun trackOrderError(
-        error: MercadoPagoCheckoutError,
+        error: ObservedCheckoutError,
         orderId: String,
     ) {
-        MPAnalytics.tryGetInstance()?.trackMetric(
+        errorObservability.track(error, NativeErrorOperation.ORDER_SUBMISSION) { eventId ->
             metricOrderError(
-                errorType = error.toErrorTypeString(),
+                errorType = error.publicError.toErrorTypeString(),
                 orderId = orderId,
-            ),
-        )
+                observabilityEventId = eventId,
+            )
+        }
     }
 
     fun trackUserCanceled(
         reason: CancelReason,
     ) {
         canceled = true
-        MPAnalytics.tryGetInstance()?.trackMetric(
-            metricCardFormUserCanceledError(errorType = reason.analyticsValue),
-        )
+        errorObservability.trackCancellation(NativeErrorOperation.CARD_FORM_CANCELLATION) { eventId ->
+            metricCardFormUserCanceledError(
+                errorType = reason.analyticsValue,
+                observabilityEventId = eventId,
+            )
+        }
     }
 }

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModel.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModel.kt
@@ -375,7 +375,7 @@ internal class CardPaymentViewModel(
                 },
                 onError = { error ->
                     analyticsTracker.trackInitializeError(error)
-                    _viewEvent.value = CardPaymentViewEvent.OnFailure(error)
+                    _viewEvent.value = CardPaymentViewEvent.OnFailure(error.publicError)
                 },
             ).apply {
                 _viewState.value = _viewState.value.copy(isLoading = false)
@@ -489,7 +489,7 @@ internal class CardPaymentViewModel(
                 onSuccess = { cardToken -> handleToken(token = cardToken.token, payer = payer) },
                 onError = { checkoutError ->
                     analyticsTracker.trackSubmitError(checkoutError)
-                    _viewEvent.value = CardPaymentViewEvent.OnFailure(checkoutError)
+                    _viewEvent.value = CardPaymentViewEvent.OnFailure(checkoutError.publicError)
                 },
             ).apply {
                 _viewState.value = _viewState.value.copy(
@@ -596,7 +596,7 @@ internal class CardPaymentViewModel(
             },
             onError = { error ->
                 analyticsTracker.trackOrderError(error = error, orderId = orderId)
-                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.Error(error))
+                CheckoutCallbackHolder.notify(MercadoPagoCheckoutResult.Error(error.publicError))
                 _viewState.value = _viewState.value.copy(isLoading = false)
                 pendingOrderData = null
             },

--- a/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/InstallmentsAnalyticsTracker.kt
+++ b/checkout/src/main/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/InstallmentsAnalyticsTracker.kt
@@ -1,6 +1,8 @@
 package com.mercadopago.sdk.android.checkout.presentation.viewmodel
 
 import com.mercadopago.sdk.android.analytics.domain.interactor.MPAnalytics
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorOperation
+import com.mercadopago.sdk.android.checkout.analytics.CheckoutErrorObservability
 import com.mercadopago.sdk.android.checkout.analytics.InstallmentsCancelReason
 import com.mercadopago.sdk.android.checkout.analytics.InstallmentsInitializeEventData
 import com.mercadopago.sdk.android.checkout.analytics.metricInstallmentsInitialize
@@ -17,6 +19,7 @@ internal class InstallmentsAnalyticsTracker(
     private val paymentData: MPPaymentData,
     private val installmentData: MPInstallmentData,
     private val orderId: String,
+    private val errorObservability: CheckoutErrorObservability = CheckoutErrorObservability(),
 ) {
     private var terminated = false
 
@@ -70,8 +73,11 @@ internal class InstallmentsAnalyticsTracker(
     ) {
         if (terminated) return
         terminated = true
-        MPAnalytics.tryGetInstance()?.trackMetric(
-            metricInstallmentsUserCanceledError(errorType = reason.analyticsValue),
-        )
+        errorObservability.trackCancellation(NativeErrorOperation.INSTALLMENTS_CANCELLATION) { eventId ->
+            metricInstallmentsUserCanceledError(
+                errorType = reason.analyticsValue,
+                observabilityEventId = eventId,
+            )
+        }
     }
 }

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/CardFormInitAnalyticsTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/CardFormInitAnalyticsTest.kt
@@ -1,6 +1,5 @@
 package com.mercadopago.sdk.android.checkout.analytics
 
-import com.mercadopago.sdk.android.analytics.domain.constants.MetricErrorData
 import com.mercadopago.sdk.android.analytics.domain.models.TrackType
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -59,11 +58,15 @@ internal class CardFormInitAnalyticsTest {
 
     @Test
     fun `when metricCardFormInitializeError called then returns error path with MetricErrorData`() {
-        val metric = metricCardFormInitializeError(errorType = "network_error")
+        val metric = metricCardFormInitializeError(
+            errorType = "network_error",
+            observabilityEventId = "event-id",
+        )
 
         assertEquals("/checkout_api_native/checkout/card_form/initialize_error", metric.path)
         assertEquals(TrackType.EVENT, metric.type)
-        val data = assertIs<MetricErrorData>(metric.data)
+        val data = assertIs<CheckoutErrorEventData>(metric.data)
         assertEquals("network_error", data.errorType)
+        assertEquals("event-id", data.observabilityEventId)
     }
 }

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/CardFormSubmitAnalyticsTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/CardFormSubmitAnalyticsTest.kt
@@ -1,6 +1,5 @@
 package com.mercadopago.sdk.android.checkout.analytics
 
-import com.mercadopago.sdk.android.analytics.domain.constants.MetricErrorData
 import com.mercadopago.sdk.android.analytics.domain.models.TrackType
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -57,29 +56,35 @@ internal class CardFormSubmitAnalyticsTest {
 
     @Test
     fun `when metricCardFormSubmitError called then returns error path with MetricErrorData`() {
-        val metric = metricCardFormSubmitError(errorType = "network_error")
+        val metric = metricCardFormSubmitError(
+            errorType = "network_error",
+            observabilityEventId = "event-id",
+        )
 
         assertEquals("/checkout_api_native/checkout/card_form/submit_error", metric.path)
         assertEquals(TrackType.EVENT, metric.type)
-        val data = assertIs<MetricErrorData>(metric.data)
+        val data = assertIs<CheckoutErrorEventData>(metric.data)
         assertEquals("network_error", data.errorType)
     }
 
     @Test
     fun `when metricCardFormUserCanceledError called then returns correct path`() {
-        val metric = metricCardFormUserCanceledError()
+        val metric = metricCardFormUserCanceledError(observabilityEventId = "event-id")
 
         assertEquals("/checkout_api_native/checkout/card_form/user_canceled_error", metric.path)
         assertEquals(TrackType.EVENT, metric.type)
-        val data = assertIs<MetricErrorData>(metric.data)
+        val data = assertIs<CheckoutErrorEventData>(metric.data)
         assertEquals("", data.errorType)
     }
 
     @Test
     fun `when metricCardFormUserCanceledError called with error then data contains it`() {
-        val metric = metricCardFormUserCanceledError(errorType = "network_error")
+        val metric = metricCardFormUserCanceledError(
+            errorType = "network_error",
+            observabilityEventId = "event-id",
+        )
 
-        val data = assertIs<MetricErrorData>(metric.data)
+        val data = assertIs<CheckoutErrorEventData>(metric.data)
         assertEquals("network_error", data.errorType)
     }
 }

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/CheckoutErrorObservabilityTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/CheckoutErrorObservabilityTest.kt
@@ -1,0 +1,71 @@
+package com.mercadopago.sdk.android.checkout.analytics
+
+import com.mercadopago.sdk.android.analytics.domain.interactor.MPAnalytics
+import com.mercadopago.sdk.android.analytics.domain.models.NativeError
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorCode
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorDiagnostic
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorOperation
+import com.mercadopago.sdk.android.checkout.domain.exception.ErrorCode
+import com.mercadopago.sdk.android.checkout.domain.exception.ErrorLocalized
+import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.ObservedCheckoutError
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class CheckoutErrorObservabilityTest {
+    private val analytics = mockk<MPAnalytics>(relaxed = true)
+    private val observability = CheckoutErrorObservability { analytics }
+
+    @Test
+    fun `track sends retained safe fields and shares reporter ID with legacy metric`() {
+        val nativeError = slot<NativeError>()
+        val legacyFactory = slot<(String) -> com.mercadopago.sdk.android.analytics.domain.models.Metric>()
+        every { analytics.trackError(capture(nativeError), capture(legacyFactory)) } returns Unit
+        val observed = ObservedCheckoutError(
+            publicError = MercadoPagoCheckoutError.ServiceError(
+                code = ErrorCode.SERVICE_ERROR,
+                messageError = "private raw service message",
+                localized = ErrorLocalized.ORDER_PROCESS.name,
+            ),
+            nativeCode = NativeErrorCode.UPSTREAM_REJECTED,
+            httpStatus = 503,
+        )
+
+        observability.track(observed, NativeErrorOperation.ORDER_SUBMISSION) { eventId ->
+            metricOrderError("service_error", "legacy-order-id", eventId)
+        }
+
+        assertEquals(NativeErrorOperation.ORDER_SUBMISSION, nativeError.captured.operation)
+        assertEquals(NativeErrorCode.UPSTREAM_REJECTED, nativeError.captured.code)
+        assertEquals(503, nativeError.captured.statusCode)
+        assertNull(nativeError.captured.requestCorrelationId)
+        val legacy = legacyFactory.captured("shared-event-id").data as OrderErrorEventData
+        assertEquals("shared-event-id", legacy.observabilityEventId)
+        assertEquals("legacy-order-id", legacy.orderId)
+    }
+
+    @Test
+    fun `cancellation is non critical and contains failures`() {
+        every { analytics.trackError(any(), any()) } throws IllegalStateException("reporter unavailable")
+
+        observability.trackCancellation(NativeErrorOperation.CARD_FORM_CANCELLATION) {
+            metricCardFormUserCanceledError("system_back", it)
+        }
+
+        verify(exactly = 1) {
+            analytics.trackError(
+                match {
+                    it.code == NativeErrorCode.USER_CANCELLED &&
+                        it.diagnostic == NativeErrorDiagnostic.CANCELLED &&
+                        !it.code.critical
+                },
+                any(),
+            )
+        }
+    }
+}

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/InstallmentsSelectionAnalyticsTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/analytics/InstallmentsSelectionAnalyticsTest.kt
@@ -1,6 +1,5 @@
 package com.mercadopago.sdk.android.checkout.analytics
 
-import com.mercadopago.sdk.android.analytics.domain.constants.MetricErrorData
 import com.mercadopago.sdk.android.analytics.domain.models.TrackType
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -35,19 +34,25 @@ internal class InstallmentsSelectionAnalyticsTest {
 
     @Test
     fun `when metricInstallmentsUserCanceledError called with back_pressed then returns error data`() {
-        val metric = metricInstallmentsUserCanceledError(errorType = "back_pressed")
+        val metric = metricInstallmentsUserCanceledError(
+            errorType = "back_pressed",
+            observabilityEventId = "event-id",
+        )
 
         assertEquals("/checkout_api_native/checkout/installments/user_canceled_error", metric.path)
         assertEquals(TrackType.EVENT, metric.type)
-        val data = assertIs<MetricErrorData>(metric.data)
+        val data = assertIs<CheckoutErrorEventData>(metric.data)
         assertEquals("back_pressed", data.errorType)
     }
 
     @Test
     fun `when metricInstallmentsUserCanceledError called with user_dismissed then returns error data`() {
-        val metric = metricInstallmentsUserCanceledError(errorType = "user_dismissed")
+        val metric = metricInstallmentsUserCanceledError(
+            errorType = "user_dismissed",
+            observabilityEventId = "event-id",
+        )
 
-        val data = assertIs<MetricErrorData>(metric.data)
+        val data = assertIs<CheckoutErrorEventData>(metric.data)
         assertEquals("user_dismissed", data.errorType)
     }
 

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/exception/ObservedCheckoutErrorFactoryTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/exception/ObservedCheckoutErrorFactoryTest.kt
@@ -1,0 +1,106 @@
+package com.mercadopago.sdk.android.checkout.domain.exception
+
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorCode
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorDiagnostic
+import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.ResponseError
+import com.mercadopago.sdk.android.coremethods.domain.model.ResultError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+internal class ObservedCheckoutErrorFactoryTest {
+    @Test
+    fun `retained validation maps without changing the legacy public error`() {
+        val observed = ObservedCheckoutErrorFactory.from(
+            ResultError.Validation("private validation detail"),
+            ErrorLocalized.TOKENIZATION,
+        )
+
+        assertEquals(NativeErrorCode.INPUT_VALIDATION_FAILED, observed.nativeCode)
+        assertEquals(NativeErrorDiagnostic.VALIDATION, observed.diagnostic)
+        assertIs<MercadoPagoCheckoutError.ServiceError>(observed.publicError)
+        assertEquals(ErrorCode.SERVICE_ERROR, observed.publicError.errorCode)
+        assertEquals(ErrorLocalized.TOKENIZATION.name, observed.publicError.errorLocalized)
+    }
+
+    @Test
+    fun `connection source codes map to connection unavailable`() {
+        listOf("NETWORK_CONNECTION_FAILED", "NO_INTERNET", "CONNECTION", "NETWORK", "UNREACHABLE")
+            .forEach { code ->
+                val observed = response(code)
+
+                assertEquals(NativeErrorCode.CONNECTION_UNAVAILABLE, observed.nativeCode, code)
+                assertEquals(NativeErrorDiagnostic.OFFLINE, observed.diagnostic, code)
+            }
+    }
+
+    @Test
+    fun `timeout source codes and reliable statuses map to request timeout`() {
+        listOf("NETWORK_TIMEOUT", "TIMEOUT").forEach { code ->
+            assertEquals(NativeErrorCode.REQUEST_TIMEOUT, response(code).nativeCode, code)
+        }
+        listOf(408, 504).forEach { status ->
+            val observed = response("SERVICE_ERROR", status)
+
+            assertEquals(NativeErrorCode.REQUEST_TIMEOUT, observed.nativeCode, status.toString())
+            assertEquals(status, observed.httpStatus)
+            assertEquals(NativeErrorDiagnostic.TIMEOUT, observed.diagnostic)
+        }
+    }
+
+    @Test
+    fun `empty body maps to response contract invalid`() {
+        val observed = response("EMPTY_BODY")
+
+        assertEquals(NativeErrorCode.RESPONSE_CONTRACT_INVALID, observed.nativeCode)
+        assertEquals(NativeErrorDiagnostic.EMPTY_BODY, observed.diagnostic)
+    }
+
+    @Test
+    fun `configuration source and auth statuses take precedence`() {
+        listOf("CONFIGURATION_ERROR", "INTEGRATION_ERROR").forEach { code ->
+            assertEquals(NativeErrorCode.SDK_CONFIGURATION_INVALID, response(code).nativeCode, code)
+        }
+        listOf(401, 403).forEach { status ->
+            val observed = response("SERVICE_ERROR", status)
+
+            assertEquals(NativeErrorCode.SDK_CONFIGURATION_INVALID, observed.nativeCode, status.toString())
+        }
+    }
+
+    @Test
+    fun `known service rejection maps upstream and unknown sources map operation failed`() {
+        assertEquals(NativeErrorCode.UPSTREAM_REJECTED, response("SERVER_ERROR", 500).nativeCode)
+        listOf("EXCEPTION", "UNKNOWN_ERROR").forEach { code ->
+            assertEquals(NativeErrorCode.OPERATION_FAILED, response(code).nativeCode, code)
+        }
+    }
+
+    @Test
+    fun `only reliable HTTP status range is retained`() {
+        assertEquals(599, response("SERVER_ERROR", 599).httpStatus)
+        assertNull(response("SERVER_ERROR", 99).httpStatus)
+        assertNull(response("SERVER_ERROR", 600).httpStatus)
+        assertNull(
+            ObservedCheckoutErrorFactory.from(
+                ResultError.Request("private raw message", "SERVER_ERROR"),
+                ErrorLocalized.TOKENIZATION,
+            ).httpStatus,
+        )
+    }
+
+    private fun response(
+        code: String,
+        status: Int? = null,
+    ) =
+        ObservedCheckoutErrorFactory.from(
+            ResponseError(
+                code = code,
+                message = "private raw message",
+                httpStatus = status,
+            ),
+            ErrorLocalized.CARD_FORM_INITIALIZATION,
+        )
+}

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/usecase/InitializeCardFormUseCaseTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/usecase/InitializeCardFormUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.mercadopago.sdk.android.checkout.domain.exception.ErrorCode
 import com.mercadopago.sdk.android.checkout.domain.exception.ErrorLocalized
 import com.mercadopago.sdk.android.checkout.domain.model.CardFormInitializationOutput
 import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.ObservedCheckoutError
 import com.mercadopago.sdk.android.checkout.domain.model.ResponseError
 import com.mercadopago.sdk.android.checkout.domain.model.params.InitializeCardFormParams
 import com.mercadopago.sdk.android.checkout.domain.repository.CardFormRepository
@@ -51,8 +52,8 @@ internal class InitializeCardFormUseCaseTest {
 
         val result = useCase(orderId, clientToken, checkoutType)
 
-        assertIs<Result.Error<MercadoPagoCheckoutError>>(result)
-        val checkoutError = result.error
+        val observedError = assertIs<Result.Error<ObservedCheckoutError>>(result).error
+        val checkoutError = observedError.publicError
         assertIs<MercadoPagoCheckoutError.ServiceError>(checkoutError)
         assertEquals(ErrorCode.SERVICE_ERROR, checkoutError.errorCode)
         assertEquals(ErrorLocalized.CARD_FORM_INITIALIZATION.name, checkoutError.errorLocalized)
@@ -65,8 +66,8 @@ internal class InitializeCardFormUseCaseTest {
 
         val result = useCase(orderId, clientToken, checkoutType)
 
-        assertIs<Result.Error<MercadoPagoCheckoutError>>(result)
-        val checkoutError = result.error
+        val observedError = assertIs<Result.Error<ObservedCheckoutError>>(result).error
+        val checkoutError = observedError.publicError
         assertIs<MercadoPagoCheckoutError.NetworkError>(checkoutError)
         assertEquals(ErrorCode.NETWORK_CONNECTION_FAILED, checkoutError.errorCode)
         assertEquals(ErrorLocalized.CARD_FORM_INITIALIZATION.name, checkoutError.errorLocalized)
@@ -80,7 +81,8 @@ internal class InitializeCardFormUseCaseTest {
 
         val result = useCase(orderId, clientToken, checkoutType)
 
-        assertIs<Result.Error<MercadoPagoCheckoutError>>(result)
+        val observedError = assertIs<Result.Error<ObservedCheckoutError>>(result).error
+        assertIs<MercadoPagoCheckoutError.ServiceError>(observedError.publicError)
     }
 
     @Test

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/usecase/ProcessOrderUseCaseTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/domain/usecase/ProcessOrderUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.mercadopago.sdk.android.checkout.domain.usecase
 import com.mercadopago.sdk.android.checkout.domain.exception.ErrorCode
 import com.mercadopago.sdk.android.checkout.domain.exception.ErrorLocalized
 import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.ObservedCheckoutError
 import com.mercadopago.sdk.android.checkout.domain.model.OrderProcessOutput
 import com.mercadopago.sdk.android.checkout.domain.model.ResponseError
 import com.mercadopago.sdk.android.checkout.domain.model.params.ProcessOrderParams
@@ -49,7 +50,7 @@ internal class ProcessOrderUseCaseTest {
 
         val result = useCase(params)
 
-        val checkoutError = assertIs<Result.Error<MercadoPagoCheckoutError>>(result).error
+        val checkoutError = assertIs<Result.Error<ObservedCheckoutError>>(result).error.publicError
         assertIs<MercadoPagoCheckoutError.ServiceError>(checkoutError)
         assertEquals(ErrorCode.SERVICE_ERROR, checkoutError.errorCode)
         assertEquals(ErrorLocalized.ORDER_PROCESS.name, checkoutError.errorLocalized)
@@ -62,7 +63,7 @@ internal class ProcessOrderUseCaseTest {
 
         val result = useCase(params)
 
-        val checkoutError = assertIs<Result.Error<MercadoPagoCheckoutError>>(result).error
+        val checkoutError = assertIs<Result.Error<ObservedCheckoutError>>(result).error.publicError
         assertIs<MercadoPagoCheckoutError.NetworkError>(checkoutError)
         assertEquals(ErrorCode.NETWORK_CONNECTION_FAILED, checkoutError.errorCode)
         assertEquals(ErrorLocalized.ORDER_PROCESS.name, checkoutError.errorLocalized)
@@ -74,7 +75,8 @@ internal class ProcessOrderUseCaseTest {
 
         val result = useCase(params)
 
-        assertIs<Result.Error<MercadoPagoCheckoutError>>(result)
+        val observedError = assertIs<Result.Error<ObservedCheckoutError>>(result).error
+        assertIs<MercadoPagoCheckoutError.ServiceError>(observedError.publicError)
     }
 
     @Test

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/usecase/GenerateTokenUseCaseTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/usecase/GenerateTokenUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.mercadopago.sdk.android.checkout.presentation.usecase
 import com.mercadopago.sdk.android.checkout.domain.exception.ErrorCode
 import com.mercadopago.sdk.android.checkout.domain.exception.ErrorLocalized
 import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.ObservedCheckoutError
 import com.mercadopago.sdk.android.coremethods.domain.interactor.CoreMethods
 import com.mercadopago.sdk.android.coremethods.domain.model.BuyerIdentification
 import com.mercadopago.sdk.android.coremethods.domain.model.CardToken
@@ -47,10 +48,10 @@ internal class GenerateTokenUseCaseTest {
 
         val result = useCase(cardNumberState, expirationDateState, securityCodeState, buyerIdentification)
 
-        assertIs<Result.Error<MercadoPagoCheckoutError>>(result)
-        assertIs<MercadoPagoCheckoutError.NetworkError>(result.error)
-        assertEquals(ErrorCode.NETWORK_CONNECTION_FAILED, result.error.errorCode)
-        assertEquals(ErrorLocalized.TOKENIZATION.name, result.error.errorLocalized)
+        val publicError = assertIs<Result.Error<ObservedCheckoutError>>(result).error.publicError
+        assertIs<MercadoPagoCheckoutError.NetworkError>(publicError)
+        assertEquals(ErrorCode.NETWORK_CONNECTION_FAILED, publicError.errorCode)
+        assertEquals(ErrorLocalized.TOKENIZATION.name, publicError.errorLocalized)
     }
 
     @Test
@@ -62,10 +63,10 @@ internal class GenerateTokenUseCaseTest {
 
         val result = useCase(cardNumberState, expirationDateState, securityCodeState, buyerIdentification)
 
-        assertIs<Result.Error<MercadoPagoCheckoutError>>(result)
-        assertIs<MercadoPagoCheckoutError.NetworkError>(result.error)
-        assertEquals(ErrorCode.NETWORK_TIMEOUT, result.error.errorCode)
-        assertEquals(ErrorLocalized.TOKENIZATION.name, result.error.errorLocalized)
+        val publicError = assertIs<Result.Error<ObservedCheckoutError>>(result).error.publicError
+        assertIs<MercadoPagoCheckoutError.NetworkError>(publicError)
+        assertEquals(ErrorCode.NETWORK_TIMEOUT, publicError.errorCode)
+        assertEquals(ErrorLocalized.TOKENIZATION.name, publicError.errorLocalized)
     }
 
     @Test
@@ -77,10 +78,10 @@ internal class GenerateTokenUseCaseTest {
 
         val result = useCase(cardNumberState, expirationDateState, securityCodeState, buyerIdentification)
 
-        assertIs<Result.Error<MercadoPagoCheckoutError>>(result)
-        assertIs<MercadoPagoCheckoutError.ServiceError>(result.error)
-        assertEquals(ErrorCode.SERVICE_ERROR, result.error.errorCode)
-        assertEquals(ErrorLocalized.TOKENIZATION.name, result.error.errorLocalized)
+        val publicError = assertIs<Result.Error<ObservedCheckoutError>>(result).error.publicError
+        assertIs<MercadoPagoCheckoutError.ServiceError>(publicError)
+        assertEquals(ErrorCode.SERVICE_ERROR, publicError.errorCode)
+        assertEquals(ErrorLocalized.TOKENIZATION.name, publicError.errorLocalized)
     }
 
     @Test
@@ -92,9 +93,9 @@ internal class GenerateTokenUseCaseTest {
 
         val result = useCase(cardNumberState, expirationDateState, securityCodeState, buyerIdentification)
 
-        assertIs<Result.Error<MercadoPagoCheckoutError>>(result)
-        assertIs<MercadoPagoCheckoutError.ServiceError>(result.error)
-        assertEquals(ErrorCode.SERVICE_ERROR, result.error.errorCode)
-        assertEquals(ErrorLocalized.TOKENIZATION.name, result.error.errorLocalized)
+        val publicError = assertIs<Result.Error<ObservedCheckoutError>>(result).error.publicError
+        assertIs<MercadoPagoCheckoutError.ServiceError>(publicError)
+        assertEquals(ErrorCode.SERVICE_ERROR, publicError.errorCode)
+        assertEquals(ErrorLocalized.TOKENIZATION.name, publicError.errorLocalized)
     }
 }

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardFormAnalyticsTrackerTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardFormAnalyticsTrackerTest.kt
@@ -1,6 +1,8 @@
 package com.mercadopago.sdk.android.checkout.presentation.viewmodel
 
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorCode
 import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.ObservedCheckoutError
 import com.mercadopago.sdk.android.checkout.presentation.model.CancelReason
 import io.mockk.mockk
 import kotlin.test.Test
@@ -104,14 +106,24 @@ internal class CardFormAnalyticsTrackerTest {
     fun `given error then trackInitializeError does not throw`() {
         val tracker = CardFormAnalyticsTracker(isLoading = { false })
 
-        tracker.trackInitializeError(mockk<MercadoPagoCheckoutError>(relaxed = true))
+        tracker.trackInitializeError(
+            ObservedCheckoutError(
+                mockk<MercadoPagoCheckoutError>(relaxed = true),
+                NativeErrorCode.OPERATION_FAILED,
+            ),
+        )
     }
 
     @Test
     fun `given error then trackSubmitError does not throw`() {
         val tracker = CardFormAnalyticsTracker(isLoading = { false })
 
-        tracker.trackSubmitError(mockk<MercadoPagoCheckoutError>(relaxed = true))
+        tracker.trackSubmitError(
+            ObservedCheckoutError(
+                mockk<MercadoPagoCheckoutError>(relaxed = true),
+                NativeErrorCode.OPERATION_FAILED,
+            ),
+        )
     }
 
     @Test

--- a/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModelTest.kt
+++ b/checkout/src/test/java/com/mercadopago/sdk/android/checkout/presentation/viewmodel/CardPaymentViewModelTest.kt
@@ -4,6 +4,7 @@ package com.mercadopago.sdk.android.checkout.presentation.viewmodel
 
 import com.mercadopago.sdk.android.analytics.domain.interactor.MPAnalytics
 import com.mercadopago.sdk.android.analytics.domain.models.Metric
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorCode
 import com.mercadopago.sdk.android.checkout.analytics.OrderSubmitEventData
 import com.mercadopago.sdk.android.checkout.core.model.MPCardBrand
 import com.mercadopago.sdk.android.checkout.core.model.MPCardType
@@ -23,6 +24,7 @@ import com.mercadopago.sdk.android.checkout.domain.model.LengthRange
 import com.mercadopago.sdk.android.checkout.domain.model.MPInstallmentData
 import com.mercadopago.sdk.android.checkout.domain.model.MPPaymentData
 import com.mercadopago.sdk.android.checkout.domain.model.MercadoPagoCheckoutError
+import com.mercadopago.sdk.android.checkout.domain.model.ObservedCheckoutError
 import com.mercadopago.sdk.android.checkout.domain.model.OrderProcessOutput
 import com.mercadopago.sdk.android.checkout.domain.model.Quota
 import com.mercadopago.sdk.android.checkout.domain.model.SecurityCodeField
@@ -63,6 +65,7 @@ import org.junit.Rule
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @Suppress("LargeClass")
@@ -94,11 +97,18 @@ internal class CardPaymentViewModelTest {
         localized = "checkout",
         throwable = null,
     )
+    private val observedNetworkError = ObservedCheckoutError(
+        publicError = networkError,
+        nativeCode = NativeErrorCode.CONNECTION_UNAVAILABLE,
+    )
 
     @Before
     fun setup() {
         mockkObject(MPAnalytics.Companion)
         every { MPAnalytics.tryGetInstance() } returns mockMPAnalytics
+        every { mockMPAnalytics.trackError(any(), any()) } answers {
+            mockMPAnalytics.trackMetric(secondArg<(String) -> Metric>().invoke("event-id"))
+        }
         mockkObject(MercadoPagoSDK.Companion)
         every { MercadoPagoSDK.countryCode } returns null
         mockkObject(CheckoutCallbackHolder)
@@ -148,7 +158,7 @@ internal class CardPaymentViewModelTest {
 
     @Test
     fun `when initialization fails then isLoading is false`() = runTest {
-        coEvery { initializeCardFormUseCase(any(), any(), any()) } returns Result.Error(networkError)
+        coEvery { initializeCardFormUseCase(any(), any(), any()) } returns Result.Error(observedNetworkError)
         val viewModel = makeViewModel()
 
         viewModel.initialization()
@@ -158,17 +168,18 @@ internal class CardPaymentViewModelTest {
 
     @Test
     fun `when initialization fails then emits OnFailure view event`() = runTest {
-        coEvery { initializeCardFormUseCase(any(), any(), any()) } returns Result.Error(networkError)
+        coEvery { initializeCardFormUseCase(any(), any(), any()) } returns Result.Error(observedNetworkError)
         val viewModel = makeViewModel()
 
         viewModel.initialization()
 
-        assertTrue(viewModel.viewEvent.value is CardPaymentViewEvent.OnFailure)
+        val event = viewModel.viewEvent.value as CardPaymentViewEvent.OnFailure
+        assertSame(networkError, event.error)
     }
 
     @Test
     fun `when initialization fails then tracks initialize_error event`() = runTest {
-        coEvery { initializeCardFormUseCase(any(), any(), any()) } returns Result.Error(networkError)
+        coEvery { initializeCardFormUseCase(any(), any(), any()) } returns Result.Error(observedNetworkError)
         val viewModel = makeViewModel()
 
         viewModel.initialization()
@@ -558,7 +569,7 @@ internal class CardPaymentViewModelTest {
     fun `when onSubmit fails then emits OnFailure view event`() = runTest {
         coEvery {
             generateTokenUseCase(any(), any(), any(), any())
-        } returns Result.Error(networkError)
+        } returns Result.Error(observedNetworkError)
         val viewModel = makeViewModel()
 
         viewModel.onSubmit(
@@ -567,7 +578,8 @@ internal class CardPaymentViewModelTest {
             securityCodeState = mockk<PCIFieldState>(relaxed = true),
         )
 
-        assertTrue(viewModel.viewEvent.value is CardPaymentViewEvent.OnFailure)
+        val event = viewModel.viewEvent.value as CardPaymentViewEvent.OnFailure
+        assertSame(networkError, event.error)
     }
 
     @Test
@@ -659,7 +671,7 @@ internal class CardPaymentViewModelTest {
 
     @Test
     fun `when processOrder fails without prior submit then notifies callback with error`() = runTest {
-        coEvery { processOrderUseCase(any()) } returns Result.Error(networkError)
+        coEvery { processOrderUseCase(any()) } returns Result.Error(observedNetworkError)
         val viewModel = makeViewModel()
         viewModel.setupWithAmount()
 
@@ -667,7 +679,8 @@ internal class CardPaymentViewModelTest {
 
         val notifySlot = slot<MercadoPagoCheckoutResult<*, *>>()
         verify(exactly = 1) { CheckoutCallbackHolder.notify(capture(notifySlot)) }
-        assertTrue(notifySlot.captured is MercadoPagoCheckoutResult.Error)
+        val result = notifySlot.captured as MercadoPagoCheckoutResult.Error
+        assertSame(networkError, result.error)
     }
 
     @Test
@@ -771,7 +784,7 @@ internal class CardPaymentViewModelTest {
         coEvery {
             generateTokenUseCase(any(), any(), any(), any())
         } returns Result.Success(CardToken(token = "token_abc"))
-        coEvery { processOrderUseCase(any()) } returns Result.Error(networkError)
+        coEvery { processOrderUseCase(any()) } returns Result.Error(observedNetworkError)
         val viewModel = makeViewModel()
         viewModel.setupWithAmount()
         viewModel.onSubmit(

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/analytics/CardIssuersAnalytics.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/analytics/CardIssuersAnalytics.kt
@@ -25,12 +25,14 @@ internal fun metricCardIssuersCallSuccess(
 @KoverIgnore("in development")
 internal fun metricCardIssuersCallError(
     error: String,
+    observabilityEventId: String,
     issuers: List<String> = emptyList(),
 ) = Metric(
     path = "$SDK_NATIVE_PATH$CORE_METHODS_PATH$ISSUERS_PATH$ERROR_PATH",
     type = TrackType.EVENT,
     data = CardIssuersErrorData(
         errorType = error,
+        observabilityEventId = observabilityEventId,
         issuers = issuers,
     ),
 )
@@ -43,6 +45,8 @@ internal data class CardIssuersAnalyticsEventData(
 internal data class CardIssuersErrorData(
     @SerializedName("error_type")
     val errorType: String,
+    @SerializedName("observability_event_id")
+    val observabilityEventId: String,
     @SerializedName("issuers")
     val issuers: List<String>,
 ) : EventData

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/analytics/CoreMethodsErrorObservability.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/analytics/CoreMethodsErrorObservability.kt
@@ -1,0 +1,70 @@
+package com.mercadopago.sdk.android.coremethods.analytics
+
+import com.mercadopago.sdk.android.analytics.domain.interactor.MPAnalytics
+import com.mercadopago.sdk.android.analytics.domain.models.Metric
+import com.mercadopago.sdk.android.analytics.domain.models.NativeError
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorCode
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorDiagnostic
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorOperation
+import com.mercadopago.sdk.android.coremethods.domain.model.ResultError
+import java.util.Locale
+
+internal class CoreMethodsErrorObservability(
+    private val analyticsProvider: () -> MPAnalytics? = MPAnalytics::tryGetInstance,
+) {
+    fun track(
+        error: ResultError,
+        operation: NativeErrorOperation,
+        legacyMetricFactory: (String) -> Metric,
+    ) {
+        try {
+            analyticsProvider()?.trackError(
+                error = NativeError(
+                    operation = operation,
+                    code = error.toNativeErrorCode(),
+                    diagnostic = error.toDiagnostic(),
+                ),
+                legacyMetricFactory = legacyMetricFactory,
+            )
+        } catch (_: Throwable) {
+            // Analytics availability never changes the original CoreMethods Result.
+        }
+    }
+
+    internal fun ResultError.toNativeErrorCode(): NativeErrorCode =
+        when (this) {
+            is ResultError.Validation -> NativeErrorCode.INPUT_VALIDATION_FAILED
+            is ResultError.Request -> when {
+                code.uppercase(Locale.ROOT) in TIMEOUT_CODES -> NativeErrorCode.REQUEST_TIMEOUT
+                code.uppercase(Locale.ROOT) in CONNECTION_CODES -> NativeErrorCode.CONNECTION_UNAVAILABLE
+                code == EMPTY_BODY_STATUS && message == EMPTY_BODY_MESSAGE -> {
+                    NativeErrorCode.RESPONSE_CONTRACT_INVALID
+                }
+                code in CONFIGURATION_STATUS_CODES -> NativeErrorCode.SDK_CONFIGURATION_INVALID
+                code == UNKNOWN_ERROR_CODE -> NativeErrorCode.OPERATION_FAILED
+                else -> NativeErrorCode.UPSTREAM_REJECTED
+            }
+        }
+
+    private fun ResultError.toDiagnostic(): NativeErrorDiagnostic? =
+        when (this) {
+            is ResultError.Validation -> NativeErrorDiagnostic.VALIDATION
+            is ResultError.Request -> when {
+                code.uppercase(Locale.ROOT) in TIMEOUT_CODES -> NativeErrorDiagnostic.TIMEOUT
+                code.uppercase(Locale.ROOT) in CONNECTION_CODES -> NativeErrorDiagnostic.OFFLINE
+                code == EMPTY_BODY_STATUS && message == EMPTY_BODY_MESSAGE -> NativeErrorDiagnostic.EMPTY_BODY
+                code == "401" -> NativeErrorDiagnostic.HTTP_UNAUTHORIZED
+                code == "403" -> NativeErrorDiagnostic.HTTP_FORBIDDEN
+                else -> null
+            }
+        }
+
+    private companion object {
+        const val EMPTY_BODY_STATUS = "200"
+        const val EMPTY_BODY_MESSAGE = "empty body"
+        const val UNKNOWN_ERROR_CODE = "UNKNOWN_ERROR"
+        val TIMEOUT_CODES = setOf("TIMEOUT", "NETWORK_TIMEOUT", "408", "504")
+        val CONNECTION_CODES = setOf("NETWORK", "CONNECTION", "NO_INTERNET", "UNREACHABLE")
+        val CONFIGURATION_STATUS_CODES = setOf("401", "403")
+    }
+}

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/analytics/GenerateCardTokenAnalytics.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/analytics/GenerateCardTokenAnalytics.kt
@@ -30,6 +30,7 @@ internal fun metricGenerateCardTokenCallSuccess(
 @KoverIgnore("in development")
 internal fun metricGenerateCardTokenCallError(
     error: String,
+    observabilityEventId: String,
     identityType: String? = null,
     typeWallet: String = TYPE_WALLET_CORE_METHODS,
 ) = Metric(
@@ -37,6 +38,7 @@ internal fun metricGenerateCardTokenCallError(
     type = TrackType.EVENT,
     data = GenerateCardTokenErrorData(
         errorType = error,
+        observabilityEventId = observabilityEventId,
         identityType = identityType,
         typeWallet = typeWallet,
     ),
@@ -56,6 +58,8 @@ internal data class GenerateCardAnalyticsData(
 internal data class GenerateCardTokenErrorData(
     @SerializedName("error_type")
     val errorType: String,
+    @SerializedName("observability_event_id")
+    val observabilityEventId: String,
     @SerializedName("identity_document_type")
     val identityType: String?,
     @SerializedName("type_wallet")

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/analytics/IndentificationTypesAnalytics.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/analytics/IndentificationTypesAnalytics.kt
@@ -23,12 +23,14 @@ internal fun metricIdentificationCallSuccess(
 @KoverIgnore("in development")
 internal fun metricIdentificationCallError(
     error: String,
+    observabilityEventId: String,
     documentTypes: List<String> = emptyList(),
 ) = Metric(
     path = "$SDK_NATIVE_PATH$CORE_METHODS_PATH$IDENTIFICATION_TYPES_PATH$ERROR_PATH",
     type = TrackType.EVENT,
     data = IdentificationTypesErrorData(
         errorType = error,
+        observabilityEventId = observabilityEventId,
         documentTypes = documentTypes,
     ),
 )
@@ -41,6 +43,8 @@ internal data class IdentificationTypesEventData(
 internal data class IdentificationTypesErrorData(
     @SerializedName("error_type")
     val errorType: String,
+    @SerializedName("observability_event_id")
+    val observabilityEventId: String,
     @SerializedName("document_types")
     val documentTypes: List<String>,
 ) : EventData

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/analytics/InstallmentsAnalytics.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/analytics/InstallmentsAnalytics.kt
@@ -28,12 +28,14 @@ internal fun metricInstallmentsCallSuccess(
 @KoverIgnore("in development")
 internal fun metricInstallmentsCallError(
     error: String,
+    observabilityEventId: String,
     transactionAmount: BigDecimal,
 ) = Metric(
     path = "$SDK_NATIVE_PATH$CORE_METHODS_PATH$INSTALLMENTS_PATH$ERROR_PATH",
     type = TrackType.EVENT,
     data = InstallmentsErrorData(
         errorType = error,
+        observabilityEventId = observabilityEventId,
         transactionAmount = transactionAmount,
     ),
 )
@@ -50,6 +52,8 @@ internal data class InstallmentAnalyticsData(
 internal data class InstallmentsErrorData(
     @SerializedName("error_type")
     val errorType: String,
+    @SerializedName("observability_event_id")
+    val observabilityEventId: String,
     @SerializedName("transaction_amount")
     val transactionAmount: BigDecimal,
 ) : EventData

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/analytics/PaymentMethodAnalytics.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/analytics/PaymentMethodAnalytics.kt
@@ -31,6 +31,7 @@ internal fun metricPaymentMethodCallSuccess(
 @KoverIgnore("in development")
 internal fun metricPaymentMethodCallError(
     error: String,
+    observabilityEventId: String,
     issuer: String = "",
     cardBrand: String = "",
 ) = Metric(
@@ -38,6 +39,7 @@ internal fun metricPaymentMethodCallError(
     type = TrackType.EVENT,
     data = PaymentMethodErrorData(
         errorType = error,
+        observabilityEventId = observabilityEventId,
         issuer = issuer,
         cardBrand = cardBrand,
     ),
@@ -57,6 +59,8 @@ internal data class PaymentMethodEventData(
 internal data class PaymentMethodErrorData(
     @SerializedName("error_type")
     val errorType: String,
+    @SerializedName("observability_event_id")
+    val observabilityEventId: String,
     @SerializedName("issuer")
     val issuer: String,
     @SerializedName("card_brand")

--- a/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/interactor/CoreMethods.kt
+++ b/core-methods/src/main/java/com/mercadopago/sdk/android/coremethods/domain/interactor/CoreMethods.kt
@@ -2,6 +2,8 @@ package com.mercadopago.sdk.android.coremethods.domain.interactor
 
 import androidx.annotation.RestrictTo
 import com.mercadopago.sdk.android.analytics.domain.interactor.MPAnalytics
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorOperation
+import com.mercadopago.sdk.android.coremethods.analytics.CoreMethodsErrorObservability
 import com.mercadopago.sdk.android.coremethods.analytics.metricCardIssuersCallError
 import com.mercadopago.sdk.android.coremethods.analytics.metricCardIssuersCallSuccess
 import com.mercadopago.sdk.android.coremethods.analytics.metricGenerateCardTokenCallError
@@ -51,6 +53,7 @@ import java.math.BigDecimal
  */
 class CoreMethods internal constructor(
     internal val koin: Koin,
+    private val errorObservability: CoreMethodsErrorObservability = CoreMethodsErrorObservability(),
 ) {
     /**
      * Generates a secure card token from the provided card details.
@@ -108,24 +111,15 @@ class CoreMethods internal constructor(
 
         when (result) {
             is Result.Error -> {
-                when (result.error) {
-                    is ResultError.Request -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricGenerateCardTokenCallError(
-                                error = result.error.message,
-                                identityType = buyerIdentification.type,
-                            ),
-                        )
-                    }
-
-                    is ResultError.Validation -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricGenerateCardTokenCallError(
-                                error = result.error.message,
-                                identityType = buyerIdentification.type,
-                            ),
-                        )
-                    }
+                errorObservability.track(
+                    error = result.error,
+                    operation = NativeErrorOperation.CARD_TOKENIZATION,
+                ) { eventId ->
+                    metricGenerateCardTokenCallError(
+                        error = result.error.legacyMessage(),
+                        observabilityEventId = eventId,
+                        identityType = buyerIdentification.type,
+                    )
                 }
             }
 
@@ -194,24 +188,15 @@ class CoreMethods internal constructor(
         )
         when (result) {
             is Result.Error -> {
-                when (result.error) {
-                    is ResultError.Request -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricGenerateCardTokenCallError(
-                                error = result.error.message,
-                                identityType = buyerIdentification.type,
-                            ),
-                        )
-                    }
-
-                    is ResultError.Validation -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricGenerateCardTokenCallError(
-                                error = result.error.message,
-                                identityType = buyerIdentification.type,
-                            ),
-                        )
-                    }
+                errorObservability.track(
+                    error = result.error,
+                    operation = NativeErrorOperation.CARD_TOKENIZATION,
+                ) { eventId ->
+                    metricGenerateCardTokenCallError(
+                        error = result.error.legacyMessage(),
+                        observabilityEventId = eventId,
+                        identityType = buyerIdentification.type,
+                    )
                 }
             }
 
@@ -274,24 +259,15 @@ class CoreMethods internal constructor(
 
         when (result) {
             is Result.Error -> {
-                when (result.error) {
-                    is ResultError.Request -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricInstallmentsCallError(
-                                error = result.error.message,
-                                transactionAmount = amount,
-                            ),
-                        )
-                    }
-
-                    is ResultError.Validation -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricInstallmentsCallError(
-                                error = result.error.message,
-                                transactionAmount = amount,
-                            ),
-                        )
-                    }
+                errorObservability.track(
+                    error = result.error,
+                    operation = NativeErrorOperation.INSTALLMENTS,
+                ) { eventId ->
+                    metricInstallmentsCallError(
+                        error = result.error.legacyMessage(),
+                        observabilityEventId = eventId,
+                        transactionAmount = amount,
+                    )
                 }
             }
 
@@ -338,22 +314,14 @@ class CoreMethods internal constructor(
         val result = koin.get<GetIdentificationTypesUseCase>().invoke()
         when (result) {
             is Result.Error -> {
-                when (result.error) {
-                    is ResultError.Request -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricIdentificationCallError(
-                                error = result.error.message,
-                            ),
-                        )
-                    }
-
-                    is ResultError.Validation -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricIdentificationCallError(
-                                error = result.error.message,
-                            ),
-                        )
-                    }
+                errorObservability.track(
+                    error = result.error,
+                    operation = NativeErrorOperation.IDENTIFICATION_TYPES,
+                ) { eventId ->
+                    metricIdentificationCallError(
+                        error = result.error.legacyMessage(),
+                        observabilityEventId = eventId,
+                    )
                 }
             }
 
@@ -411,22 +379,14 @@ class CoreMethods internal constructor(
 
         when (result) {
             is Result.Error -> {
-                when (result.error) {
-                    is ResultError.Request -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricCardIssuersCallError(
-                                error = result.error.message,
-                            ),
-                        )
-                    }
-
-                    is ResultError.Validation -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricCardIssuersCallError(
-                                error = result.error.message,
-                            ),
-                        )
-                    }
+                errorObservability.track(
+                    error = result.error,
+                    operation = NativeErrorOperation.ISSUERS,
+                ) { eventId ->
+                    metricCardIssuersCallError(
+                        error = result.error.legacyMessage(),
+                        observabilityEventId = eventId,
+                    )
                 }
             }
 
@@ -481,22 +441,14 @@ class CoreMethods internal constructor(
 
         when (result) {
             is Result.Error -> {
-                when (result.error) {
-                    is ResultError.Request -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricPaymentMethodCallError(
-                                error = result.error.message,
-                            ),
-                        )
-                    }
-
-                    is ResultError.Validation -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricPaymentMethodCallError(
-                                error = result.error.message,
-                            ),
-                        )
-                    }
+                errorObservability.track(
+                    error = result.error,
+                    operation = NativeErrorOperation.PAYMENT_METHODS,
+                ) { eventId ->
+                    metricPaymentMethodCallError(
+                        error = result.error.legacyMessage(),
+                        observabilityEventId = eventId,
+                    )
                 }
             }
 
@@ -544,24 +496,15 @@ class CoreMethods internal constructor(
 
         when (result) {
             is Result.Error -> {
-                when (result.error) {
-                    is ResultError.Request -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricGenerateCardTokenCallError(
-                                error = result.error.message,
-                                identityType = buyerIdentification.type,
-                            ),
-                        )
-                    }
-
-                    is ResultError.Validation -> {
-                        MPAnalytics.getInstance().trackMetric(
-                            metricGenerateCardTokenCallError(
-                                error = result.error.message,
-                                identityType = buyerIdentification.type,
-                            ),
-                        )
-                    }
+                errorObservability.track(
+                    error = result.error,
+                    operation = NativeErrorOperation.CARD_TOKENIZATION,
+                ) { eventId ->
+                    metricGenerateCardTokenCallError(
+                        error = result.error.legacyMessage(),
+                        observabilityEventId = eventId,
+                        identityType = buyerIdentification.type,
+                    )
                 }
             }
 
@@ -605,6 +548,12 @@ class CoreMethods internal constructor(
         }
     }
 }
+
+private fun ResultError.legacyMessage(): String =
+    when (this) {
+        is ResultError.Request -> message
+        is ResultError.Validation -> message
+    }
 
 /**
  * Mercado Pago SDK - CoreMethods

--- a/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/analytics/CoreMethodsErrorObservabilityTest.kt
+++ b/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/analytics/CoreMethodsErrorObservabilityTest.kt
@@ -1,0 +1,92 @@
+package com.mercadopago.sdk.android.coremethods.analytics
+
+import com.mercadopago.sdk.android.analytics.domain.interactor.MPAnalytics
+import com.mercadopago.sdk.android.analytics.domain.models.Metric
+import com.mercadopago.sdk.android.analytics.domain.models.NativeError
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorCode
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorDiagnostic
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorOperation
+import com.mercadopago.sdk.android.analytics.domain.models.TrackType
+import com.mercadopago.sdk.android.coremethods.domain.model.ResultError
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class CoreMethodsErrorObservabilityTest {
+    private val analytics = mockk<MPAnalytics>(relaxed = true)
+    private val observability = CoreMethodsErrorObservability { analytics }
+
+    @Test
+    fun `classification is closed and never copies raw messages`() {
+        val cases = listOf(
+            ResultError.Validation("PAN must not leave this object") to NativeErrorCode.INPUT_VALIDATION_FAILED,
+            ResultError.Request("raw", "TIMEOUT") to NativeErrorCode.REQUEST_TIMEOUT,
+            ResultError.Request("raw", "504") to NativeErrorCode.REQUEST_TIMEOUT,
+            ResultError.Request("raw", "NO_INTERNET") to NativeErrorCode.CONNECTION_UNAVAILABLE,
+            ResultError.Request("empty body", "200") to NativeErrorCode.RESPONSE_CONTRACT_INVALID,
+            ResultError.Request("raw", "401") to NativeErrorCode.SDK_CONFIGURATION_INVALID,
+            ResultError.Request("raw", "403") to NativeErrorCode.SDK_CONFIGURATION_INVALID,
+            ResultError.Request("raw", "422") to NativeErrorCode.UPSTREAM_REJECTED,
+            ResultError.Request("raw", "UNKNOWN_ERROR") to NativeErrorCode.OPERATION_FAILED,
+        )
+
+        cases.forEach { (error, expected) ->
+            assertEquals(expected, with(observability) { error.toNativeErrorCode() })
+        }
+    }
+
+    @Test
+    fun `classification is stable in a Turkish default locale`() {
+        val previous = java.util.Locale.getDefault()
+        try {
+            java.util.Locale.setDefault(java.util.Locale("tr", "TR"))
+
+            assertEquals(
+                NativeErrorCode.REQUEST_TIMEOUT,
+                with(observability) {
+                    ResultError.Request("raw", "timeoUt").toNativeErrorCode()
+                },
+            )
+        } finally {
+            java.util.Locale.setDefault(previous)
+        }
+    }
+
+    @Test
+    fun `passes classified error and shared id without status or raw detail`() {
+        val nativeError = slot<NativeError>()
+        val factory = slot<(String) -> Metric>()
+        every { analytics.trackError(capture(nativeError), capture(factory)) } returns Unit
+
+        observability.track(
+            error = ResultError.Request(message = "secret raw message", code = "504"),
+            operation = NativeErrorOperation.ISSUERS,
+        ) { id -> Metric(TrackType.EVENT, "/legacy/$id") }
+
+        assertEquals(NativeErrorCode.REQUEST_TIMEOUT, nativeError.captured.code)
+        assertEquals(NativeErrorDiagnostic.TIMEOUT, nativeError.captured.diagnostic)
+        assertNull(nativeError.captured.statusCode)
+        assertNull(nativeError.captured.requestCorrelationId)
+        assertEquals("/legacy/shared-id", factory.captured("shared-id").path)
+    }
+
+    @Test
+    fun `missing or failing analytics never throws`() {
+        CoreMethodsErrorObservability { null }.track(
+            ResultError.Validation("raw"),
+            NativeErrorOperation.CARD_TOKENIZATION,
+        ) { mockk() }
+        every { analytics.trackError(any(), any()) } throws IllegalStateException("failed")
+
+        observability.track(
+            ResultError.Request("raw", "500"),
+            NativeErrorOperation.ISSUERS,
+        ) { mockk() }
+
+        verify(exactly = 1) { analytics.trackError(any(), any()) }
+    }
+}

--- a/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/analytics/GenerateCardTokenAnalyticsTest.kt
+++ b/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/analytics/GenerateCardTokenAnalyticsTest.kt
@@ -36,6 +36,7 @@ internal class GenerateCardTokenAnalyticsTest {
     fun `error metric uses error path with error_type, identity_document_type and type_wallet`() {
         val metric = metricGenerateCardTokenCallError(
             error = "INVALID_DATA",
+            observabilityEventId = "event-id",
             identityType = "CPF",
             typeWallet = "coremethods",
         )
@@ -44,13 +45,17 @@ internal class GenerateCardTokenAnalyticsTest {
         assertEquals(TrackType.EVENT, metric.type)
         val data = assertIs<GenerateCardTokenErrorData>(metric.data)
         assertEquals("INVALID_DATA", data.errorType)
+        assertEquals("event-id", data.observabilityEventId)
         assertEquals("CPF", data.identityType)
         assertEquals("coremethods", data.typeWallet)
     }
 
     @Test
     fun `error metric defaults type_wallet to coremethods when omitted`() {
-        val metric = metricGenerateCardTokenCallError(error = "NETWORK_ERROR")
+        val metric = metricGenerateCardTokenCallError(
+            error = "NETWORK_ERROR",
+            observabilityEventId = "event-id",
+        )
         val data = assertIs<GenerateCardTokenErrorData>(metric.data)
         assertNull(data.identityType)
         assertEquals("coremethods", data.typeWallet)

--- a/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/analytics/PaymentMethodAnalyticsTest.kt
+++ b/core-methods/src/test/java/com/mercadopago/sdk/android/coremethods/analytics/PaymentMethodAnalyticsTest.kt
@@ -43,6 +43,7 @@ internal class PaymentMethodAnalyticsTest {
     fun `error metric carries card_brand and issuer alongside error_type`() {
         val metric = metricPaymentMethodCallError(
             error = "NETWORK_ERROR",
+            observabilityEventId = "event-id",
             issuer = "24",
             cardBrand = "master",
         )
@@ -51,13 +52,17 @@ internal class PaymentMethodAnalyticsTest {
         assertEquals(TrackType.EVENT, metric.type)
         val data = assertIs<PaymentMethodErrorData>(metric.data)
         assertEquals("NETWORK_ERROR", data.errorType)
+        assertEquals("event-id", data.observabilityEventId)
         assertEquals("24", data.issuer)
         assertEquals("master", data.cardBrand)
     }
 
     @Test
     fun `error metric defaults card_brand and issuer to empty when omitted`() {
-        val metric = metricPaymentMethodCallError(error = "NETWORK_ERROR")
+        val metric = metricPaymentMethodCallError(
+            error = "NETWORK_ERROR",
+            observabilityEventId = "event-id",
+        )
         val data = assertIs<PaymentMethodErrorData>(metric.data)
         assertEquals("", data.issuer)
         assertEquals("", data.cardBrand)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,6 +93,7 @@ koin-compose = { module = "io.insert-koin:koin-androidx-compose" }
 koin-test = { module = "io.insert-koin:koin-test" }
 koin-test-junit4 = { module = "io.insert-koin:koin-test-junit4" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 
 squareup-retrofit = {module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit"}

--- a/sdk-android/src/main/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDK.kt
+++ b/sdk-android/src/main/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDK.kt
@@ -5,6 +5,7 @@ package com.mercadopago.sdk.android.initializer
 import android.content.Context
 import androidx.annotation.RestrictTo
 import com.mercadolibre.android.device.sdk.DeviceSDK
+import com.mercadopago.sdk.android.analytics.domain.interactor.MPAnalytics
 import com.mercadopago.sdk.android.core.utils.PublicKeyStore
 import com.mercadopago.sdk.android.di.MercadoPagoSdkModulesProvider
 import com.mercadopago.sdk.android.domain.model.CountryCode
@@ -32,7 +33,7 @@ class MercadoPagoSDK private constructor(
     val koin: Koin,
     internal var publicKey: String,
     internal var countryCode: CountryCode,
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     internal val sessionId: String,
     private val applicationContext: Context,
 ) {
@@ -168,6 +169,7 @@ class MercadoPagoSDK private constructor(
         fun clearInstance() {
             val instanceToClose = sdkInstance
             sdkInstance = null
+            MPAnalytics.clearInstance()
             SdkCoroutineProvider.provideSDKCoroutineScope().launch {
                 instanceToClose?.koin?.close()
             }

--- a/sdk-android/src/main/java/com/mercadopago/sdk/android/initializer/usecase/ConfigureSdkUseCase.kt
+++ b/sdk-android/src/main/java/com/mercadopago/sdk/android/initializer/usecase/ConfigureSdkUseCase.kt
@@ -3,6 +3,7 @@ package com.mercadopago.sdk.android.initializer.usecase
 import android.content.Context
 import android.util.Log
 import com.mercadopago.sdk.android.analytics.domain.interactor.MPAnalytics
+import com.mercadopago.sdk.android.data.local.mapper.toSiteId
 import com.mercadopago.sdk.android.domain.model.CountryCode
 import com.mercadopago.sdk.android.domain.usecase.GetSiteIdUseCase
 import com.mercadopago.sdk.android.domain.usecase.SetSiteIdUseCase
@@ -27,6 +28,7 @@ internal class ConfigureSdkUseCase(
         MPAnalytics.initialize(
             context = params.context,
             getSiteIdFlow = getSiteIdUseCase(params.publicKey).map { siteId -> siteId.siteId },
+            nativeSiteId = params.countryCode.toSiteId(),
         )
         return setSiteIdUseCase(params.publicKey, params.countryCode)
             .onEach {

--- a/sdk-android/src/test/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDKTest.kt
+++ b/sdk-android/src/test/java/com/mercadopago/sdk/android/initializer/MercadoPagoSDKTest.kt
@@ -56,7 +56,8 @@ internal class MercadoPagoSDKTest {
         mockkObject(SdkCoroutineProvider)
         mockkStatic(MPAnalytics::class)
         mockkObject(MPAnalytics.Companion)
-        every { MPAnalytics.initialize(any(), any()) } returns Unit
+        every { MPAnalytics.initialize(any(), any(), any()) } returns Unit
+        every { MPAnalytics.clearInstance() } returns Unit
         every { SdkInitializerAnalytics.buildSdkInitializerEvent(any(), any()) } answers { callOriginal() }
         mockkStatic(DeviceSDK::class)
         mockkStatic(Log::class)


### PR DESCRIPTION
# Pull Request

## Ticket or Issue link

- Parent: https://mercadolibre.atlassian.net/browse/CHOBK-3831
- Android tasks: CHOBK-4937 through CHOBK-4946
- Hub specification and coordination PR: https://github.com/melisource/fury_team-hub-mp-op-sdk-components/pull/69

## Description

Adds internal, best-effort native error observability for Android CoreMethods and Checkout while preserving public results, callbacks, error types, and existing Melidata behavior.

The change introduces a constructive v2 request model, a credential-free dedicated client, a bounded single-worker reporter, shared event correlation, closed error classification, Checkout error retention, lifecycle cleanup, privacy guards, and compatibility documentation. Delivery remains DUAL_WRITE and no rollout gate is enabled.

Each approved SDD task is represented by one commit and references its Jira task. All Jira work is under CHOBK-3831 and tagged observability-initiative.

## Validation

- Affected analytics, CoreMethods, Checkout, and SDK unit suites pass.
- Android lint passes for analytics, CoreMethods, Checkout, and SDK modules.
- Detekt and ktlint pass.
- Debug and release assemblies pass, including the minified example release build.
- The saturated-queue caller-path regression test passes with a p95 budget below 1 ms.
- The constructive payload deny-list and network tests verify no credential, cookie, payment, payer, device identifier, URL/body, raw error, message, or arbitrary detail fields are sent.
- Fury code review completed with zero remaining findings after the Locale.ROOT classification fix.

## External handoffs before rollout

- [ ] A reviewer applies the size-override label; the SDD implementation is intentionally larger than the repository 500-line limit and authors cannot self-apply this label.
- [ ] Public mirror CI completes and is reflected back to this private PR.
- [ ] ApplicationSecurityMCP and AppSec complete their issue-catalog and fix-suggestion review.
- [ ] Coordinated release E2E validates less than 1 percent CoreMethods and Checkout latency change and all LTP scenarios.
- [ ] Backend v2 contract is deployed and operational dashboards, monitors, rate limits, trusted corroboration, and source gates are approved.
- [ ] Keep source gates, paging, release, deployment, and observability-only cutover disabled until those handoffs pass.

## Checklist

- [x] I have tested my changes creating a local version.
- [x] I have added tests that prove my solution is effective and works.
- [x] New and existing affected unit tests pass locally with my changes.
- [x] The branch is based on the latest main commit.
- [x] I have run the repository test, lint, Detekt, ktlint, debug, release, R8, and example release gates.
- [x] Offline, timeout, redirect, non-202, queue saturation, cleanup, and framework error isolation are covered; no UI or rotation behavior changed.
- [x] Accessibility and screenshots are not applicable because this change has no UI.
- [x] The checkout product label is applied to this pull request.

## Screenshots or videos

Not applicable; no UI changes.
