### PR TITLE
[CHOBK-4937] Add Android native error pipeline foundation

### DIFF
--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/remote/mapper/NativeErrorRequestMapper.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/remote/mapper/NativeErrorRequestMapper.kt
@@ -1,0 +1,70 @@
+package com.mercadopago.sdk.android.analytics.data.remote.mapper
+
+import android.content.Context
+import android.os.Build
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorDetailRequest
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorDeviceRequest
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorRequest
+import com.mercadopago.sdk.android.analytics.data.remote.models.request.NativeErrorSourceRequest
+import com.mercadopago.sdk.android.analytics.domain.models.PendingNativeError
+import com.mercadopago.sdk.android.core.BuildConfig
+import com.mercadopago.sdk.android.core.utils.NetworkType
+import com.mercadopago.sdk.android.core.utils.checkNetworkType
+
+internal class NativeErrorRequestMapper(
+    private val context: Context,
+    private val siteId: String,
+    private val sdkVersion: String = BuildConfig.SdkVersion,
+    private val osVersion: () -> String = { Build.VERSION.RELEASE },
+    private val networkType: (Context) -> NetworkType = ::checkNetworkType,
+) {
+    fun map(pending: PendingNativeError): NativeErrorRequest {
+        val nativeError = pending.error
+        val safeOsVersion = osVersion().takeIf { SAFE_OS_VERSION.matches(it) && it.length <= MAX_OS_VERSION_LENGTH }
+        val connectivity = when (networkType(context)) {
+            NetworkType.WIFI -> "wifi"
+            NetworkType.CELLULAR_3G,
+            NetworkType.CELLULAR_4G,
+            NetworkType.CELLULAR_5G,
+            NetworkType.CELLULAR_UNKNOWN -> "cellular"
+            NetworkType.NONE -> "none"
+        }
+        return NativeErrorRequest(
+            eventId = pending.eventId,
+            occurredAt = pending.occurredAt,
+            source = NativeErrorSourceRequest(
+                sdkName = "openplatform_sdk_android",
+                sdkVersion = sdkVersion,
+                hostPlatform = "android",
+                sdkTechnology = "native",
+                module = nativeError.operation.module.value,
+                operation = nativeError.operation.value,
+            ),
+            siteId = siteId,
+            error = NativeErrorDetailRequest(
+                code = nativeError.code.value,
+                category = nativeError.code.category,
+                critical = nativeError.code.critical,
+                statusCode = nativeError.statusCode?.takeIf { it in MIN_HTTP_STATUS..MAX_HTTP_STATUS },
+                requestCorrelationId = nativeError.requestCorrelationId?.takeIf {
+                    it.length in 1..MAX_CORRELATION_ID_LENGTH && SAFE_CORRELATION_ID.matches(it)
+                },
+                serviceTarget = nativeError.operation.serviceTarget,
+                diagnosticCode = nativeError.diagnostic?.value,
+            ),
+            device = NativeErrorDeviceRequest(
+                osVersion = safeOsVersion,
+                connectivity = connectivity,
+            ),
+        )
+    }
+
+    private companion object {
+        const val MAX_CORRELATION_ID_LENGTH = 128
+        const val MAX_OS_VERSION_LENGTH = 32
+        const val MIN_HTTP_STATUS = 100
+        const val MAX_HTTP_STATUS = 599
+        val SAFE_CORRELATION_ID = Regex("[A-Za-z0-9._:-]+")
+        val SAFE_OS_VERSION = Regex("[0-9A-Za-z._+\\-]+")
+    }
+}

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/remote/models/request/NativeErrorRequest.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/data/remote/models/request/NativeErrorRequest.kt
@@ -1,0 +1,36 @@
+package com.mercadopago.sdk.android.analytics.data.remote.models.request
+
+import com.google.gson.annotations.SerializedName
+
+internal data class NativeErrorRequest(
+    @SerializedName("event_id") val eventId: String,
+    @SerializedName("occurred_at") val occurredAt: String,
+    @SerializedName("source") val source: NativeErrorSourceRequest,
+    @SerializedName("site_id") val siteId: String,
+    @SerializedName("error") val error: NativeErrorDetailRequest,
+    @SerializedName("device") val device: NativeErrorDeviceRequest?,
+)
+
+internal data class NativeErrorSourceRequest(
+    @SerializedName("sdk_name") val sdkName: String,
+    @SerializedName("sdk_version") val sdkVersion: String,
+    @SerializedName("host_platform") val hostPlatform: String,
+    @SerializedName("sdk_technology") val sdkTechnology: String,
+    @SerializedName("module") val module: String,
+    @SerializedName("operation") val operation: String,
+)
+
+internal data class NativeErrorDetailRequest(
+    @SerializedName("code") val code: String,
+    @SerializedName("category") val category: String,
+    @SerializedName("critical") val critical: Boolean,
+    @SerializedName("status_code") val statusCode: Int?,
+    @SerializedName("request_correlation_id") val requestCorrelationId: String?,
+    @SerializedName("service_target") val serviceTarget: String?,
+    @SerializedName("diagnostic_code") val diagnosticCode: String?,
+)
+
+internal data class NativeErrorDeviceRequest(
+    @SerializedName("os_version") val osVersion: String?,
+    @SerializedName("connectivity") val connectivity: String?,
+)

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeError.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeError.kt
@@ -1,0 +1,28 @@
+package com.mercadopago.sdk.android.analytics.domain.models
+
+import androidx.annotation.RestrictTo
+
+/** A privacy-safe native SDK error ready for classification and delivery. */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class NativeError(
+    /** SDK operation that failed. */
+    val operation: NativeErrorOperation,
+    /** Stable, privacy-safe error classification. */
+    val code: NativeErrorCode,
+    /** Valid HTTP status code when one is available. */
+    val statusCode: Int? = null,
+    /** Allowlisted request identifier used only for correlation. */
+    val requestCorrelationId: String? = null,
+    /** Optional diagnostic selected from the closed catalog. */
+    val diagnostic: NativeErrorDiagnostic? = null,
+)
+
+/** Internal envelope captured before the error is dispatched asynchronously. */
+internal data class PendingNativeError(
+    /** Unique identifier shared with the related Melidata event. */
+    val eventId: String,
+    /** ISO-8601 timestamp captured on the caller path. */
+    val occurredAt: String,
+    /** Classified error payload. */
+    val error: NativeError,
+)

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorCode.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorCode.kt
@@ -1,0 +1,33 @@
+package com.mercadopago.sdk.android.analytics.domain.models
+
+import androidx.annotation.RestrictTo
+
+/** Closed catalog of privacy-safe native error classifications. */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class NativeErrorCode(
+    /** Stable wire value sent to the ingestion API. */
+    val value: String,
+    /** Stable error category derived from the code. */
+    val category: String,
+    /** Whether the error is considered critical for observability. */
+    val critical: Boolean,
+) {
+    /** The buyer cancelled the flow. */
+    USER_CANCELLED("user_cancelled", "cancellation", false),
+    /** An in-flight request was cancelled. */
+    REQUEST_CANCELLED("request_cancelled", "cancellation", false),
+    /** Input validation failed before service execution. */
+    INPUT_VALIDATION_FAILED("input_validation_failed", "input_validation", false),
+    /** The network connection was unavailable. */
+    CONNECTION_UNAVAILABLE("connection_unavailable", "network", false),
+    /** A service request timed out. */
+    REQUEST_TIMEOUT("request_timeout", "service", true),
+    /** An upstream service rejected the request. */
+    UPSTREAM_REJECTED("upstream_rejected", "service", true),
+    /** The upstream response did not match its contract. */
+    RESPONSE_CONTRACT_INVALID("response_contract_invalid", "integration", true),
+    /** SDK configuration prevented the operation. */
+    SDK_CONFIGURATION_INVALID("sdk_configuration_invalid", "integration", true),
+    /** The operation failed without a more specific safe classification. */
+    OPERATION_FAILED("operation_failed", "unknown", true),
+}

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorDeliveryMode.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorDeliveryMode.kt
@@ -1,0 +1,14 @@
+package com.mercadopago.sdk.android.analytics.domain.models
+
+/** Controls which observability destinations receive native errors. */
+internal enum class NativeErrorDeliveryMode {
+    MELIDATA_ONLY,
+    DUAL_WRITE,
+    OBSERVABILITY_ONLY;
+
+    companion object {
+        /** Parses a build-time mode and fails closed to Melidata-only delivery. */
+        fun from(value: String): NativeErrorDeliveryMode =
+            values().firstOrNull { it.name == value } ?: MELIDATA_ONLY
+    }
+}

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorDiagnostic.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorDiagnostic.kt
@@ -1,0 +1,33 @@
+package com.mercadopago.sdk.android.analytics.domain.models
+
+import androidx.annotation.RestrictTo
+
+/** Closed catalog of optional, privacy-safe diagnostic details. */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class NativeErrorDiagnostic(
+    /** Stable wire value sent to the ingestion API. */
+    val value: String,
+) {
+    /** The operation was cancelled. */
+    CANCELLED("cancelled"),
+    /** Local validation rejected the input. */
+    VALIDATION("validation"),
+    /** The device was offline. */
+    OFFLINE("offline"),
+    /** DNS resolution failed. */
+    DNS_FAILURE("dns_failure"),
+    /** An established connection was lost. */
+    CONNECTION_LOST("connection_lost"),
+    /** The request exceeded its time limit. */
+    TIMEOUT("timeout"),
+    /** The service returned an empty body. */
+    EMPTY_BODY("empty_body"),
+    /** The response body could not be decoded. */
+    DECODE_FAILURE("decode_failure"),
+    /** The request URL could not be created. */
+    INVALID_URL("invalid_url"),
+    /** The service returned HTTP 401. */
+    HTTP_UNAUTHORIZED("http_unauthorized"),
+    /** The service returned HTTP 403. */
+    HTTP_FORBIDDEN("http_forbidden"),
+}

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorModule.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorModule.kt
@@ -1,0 +1,15 @@
+package com.mercadopago.sdk.android.analytics.domain.models
+
+import androidx.annotation.RestrictTo
+
+/** SDK module that originated a native error. */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class NativeErrorModule(
+    /** Stable wire value sent to the ingestion API. */
+    val value: String,
+) {
+    /** CoreMethods APIs. */
+    CORE_METHODS("core_methods"),
+    /** Native Checkout flows. */
+    CHECKOUT("checkout"),
+}

--- a/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorOperation.kt
+++ b/analytics/src/main/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorOperation.kt
@@ -1,0 +1,35 @@
+package com.mercadopago.sdk.android.analytics.domain.models
+
+import androidx.annotation.RestrictTo
+
+/** Closed catalog of observable native SDK operations. */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class NativeErrorOperation(
+    /** Stable wire value sent to the ingestion API. */
+    val value: String,
+    /** SDK module that owns the operation. */
+    val module: NativeErrorModule,
+    /** Allowlisted downstream service associated with the operation, if any. */
+    val serviceTarget: String?,
+) {
+    /** Fetching identification types. */
+    IDENTIFICATION_TYPES("identification_types", NativeErrorModule.CORE_METHODS, "identification_types"),
+    /** Fetching installments. */
+    INSTALLMENTS("installments", NativeErrorModule.CORE_METHODS, "installments"),
+    /** Fetching payment methods. */
+    PAYMENT_METHODS("payment_methods", NativeErrorModule.CORE_METHODS, "payment_methods"),
+    /** Fetching issuers. */
+    ISSUERS("issuers", NativeErrorModule.CORE_METHODS, "issuers"),
+    /** Card tokenization, which may include a preliminary lookup. */
+    CARD_TOKENIZATION("card_tokenization", NativeErrorModule.CORE_METHODS, null),
+    /** Initializing the native card form. */
+    CARD_FORM_INITIALIZATION("card_form_initialization", NativeErrorModule.CHECKOUT, "checkout_initialization"),
+    /** Submitting the native card form. */
+    CARD_FORM_SUBMISSION("card_form_submission", NativeErrorModule.CHECKOUT, null),
+    /** Cancelling the native card form. */
+    CARD_FORM_CANCELLATION("card_form_cancellation", NativeErrorModule.CHECKOUT, null),
+    /** Cancelling installments selection. */
+    INSTALLMENTS_CANCELLATION("installments_cancellation", NativeErrorModule.CHECKOUT, null),
+    /** Submitting an order. */
+    ORDER_SUBMISSION("order_submission", NativeErrorModule.CHECKOUT, "orders"),
+}

--- a/analytics/src/test/java/com/mercadopago/sdk/android/analytics/data/remote/mapper/NativeErrorRequestMapperTest.kt
+++ b/analytics/src/test/java/com/mercadopago/sdk/android/analytics/data/remote/mapper/NativeErrorRequestMapperTest.kt
@@ -1,0 +1,91 @@
+package com.mercadopago.sdk.android.analytics.data.remote.mapper
+
+import android.content.Context
+import com.google.gson.GsonBuilder
+import com.mercadopago.sdk.android.analytics.domain.models.NativeError
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorCode
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorDiagnostic
+import com.mercadopago.sdk.android.analytics.domain.models.NativeErrorOperation
+import com.mercadopago.sdk.android.analytics.domain.models.PendingNativeError
+import com.mercadopago.sdk.android.core.utils.NetworkType
+import io.mockk.mockk
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+internal class NativeErrorRequestMapperTest {
+    private val context = mockk<Context>(relaxed = true)
+
+    @Test
+    fun `maps the fixed android source and derived catalog values`() {
+        val mapper = NativeErrorRequestMapper(
+            context = context,
+            siteId = "MLB",
+            sdkVersion = "1.2.3",
+            osVersion = { "14" },
+            networkType = { NetworkType.WIFI },
+        )
+
+        val request = mapper.map(
+            PendingNativeError(
+                eventId = "3f6fd694-4ba8-4f45-ae7c-871c4698aace",
+                occurredAt = "2026-08-27T12:00:00.000Z",
+                error = NativeError(
+                    operation = NativeErrorOperation.ISSUERS,
+                    code = NativeErrorCode.REQUEST_TIMEOUT,
+                    statusCode = 504,
+                    requestCorrelationId = "request:123",
+                    diagnostic = NativeErrorDiagnostic.TIMEOUT,
+                ),
+            )
+        )
+
+        assertEquals("openplatform_sdk_android", request.source.sdkName)
+        assertEquals("android", request.source.hostPlatform)
+        assertEquals("native", request.source.sdkTechnology)
+        assertEquals("core_methods", request.source.module)
+        assertEquals("issuers", request.source.operation)
+        assertEquals("request_timeout", request.error.code)
+        assertEquals("service", request.error.category)
+        assertEquals(true, request.error.critical)
+        assertEquals("issuers", request.error.serviceTarget)
+        assertEquals("wifi", request.device?.connectivity)
+    }
+
+    @Test
+    fun `omits invalid optional values and Gson never serializes null fields`() {
+        val mapper = NativeErrorRequestMapper(
+            context = context,
+            siteId = "MLA",
+            sdkVersion = "1.0.0",
+            osVersion = { "invalid value" },
+            networkType = { NetworkType.NONE },
+        )
+        val request = mapper.map(
+            PendingNativeError(
+                eventId = "3f6fd694-4ba8-4f45-ae7c-871c4698aace",
+                occurredAt = "2026-08-27T12:00:00.000Z",
+                error = NativeError(
+                    operation = NativeErrorOperation.CARD_TOKENIZATION,
+                    code = NativeErrorCode.OPERATION_FAILED,
+                    statusCode = 99,
+                    requestCorrelationId = "not safe!",
+                ),
+            )
+        )
+
+        assertNull(request.error.statusCode)
+        assertNull(request.error.requestCorrelationId)
+        assertNull(request.error.serviceTarget)
+        assertNull(request.device?.osVersion)
+        val json = GsonBuilder().create().toJson(request)
+        assertFalse(json.contains("status_code"))
+        assertFalse(json.contains("request_correlation_id"))
+        assertFalse(json.contains("service_target"))
+        assertFalse(json.contains("message"))
+        assertFalse(json.contains("public_key"))
+        assertFalse(json.contains("package"))
+        assertFalse(json.contains("url"))
+    }
+}

--- a/analytics/src/test/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorTest.kt
+++ b/analytics/src/test/java/com/mercadopago/sdk/android/analytics/domain/models/NativeErrorTest.kt
@@ -1,0 +1,30 @@
+package com.mercadopago.sdk.android.analytics.domain.models
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class NativeErrorTest {
+    @Test
+    fun `catalog derives category criticality module and service target`() {
+        assertEquals("input_validation", NativeErrorCode.INPUT_VALIDATION_FAILED.category)
+        assertFalse(NativeErrorCode.INPUT_VALIDATION_FAILED.critical)
+        assertEquals("service", NativeErrorCode.REQUEST_TIMEOUT.category)
+        assertTrue(NativeErrorCode.REQUEST_TIMEOUT.critical)
+        assertEquals(NativeErrorModule.CORE_METHODS, NativeErrorOperation.ISSUERS.module)
+        assertEquals("issuers", NativeErrorOperation.ISSUERS.serviceTarget)
+        assertNull(NativeErrorOperation.CARD_TOKENIZATION.serviceTarget)
+        assertEquals(NativeErrorModule.CHECKOUT, NativeErrorOperation.ORDER_SUBMISSION.module)
+        assertEquals("orders", NativeErrorOperation.ORDER_SUBMISSION.serviceTarget)
+    }
+
+    @Test
+    fun `unknown delivery mode fails closed to melidata only`() {
+        assertEquals(
+            NativeErrorDeliveryMode.MELIDATA_ONLY,
+            NativeErrorDeliveryMode.from("unexpected")
+        )
+    }
+}


### PR DESCRIPTION
# Pull Request

## Tickets

- Task: https://mercadolibre.atlassian.net/browse/CHOBK-4937
- Parent: https://mercadolibre.atlassian.net/browse/CHOBK-3831
- Hub: https://github.com/melisource/fury_team-hub-mp-op-sdk-components/pull/69

## Description

Stack 1 of 6. Adds the production-only Android foundation for native error observability: closed catalog, constructive DTO mapper, credential-free v2 client, repository/use case, Koin bindings, and dependency wiring.

This focused PR contains 319 changed lines. The original aggregate PR remains available as backup at #194. Delivery remains DUAL_WRITE and no rollout gate is enabled.

## Validation

- Final stack tree is byte-identical to #194.
- Focused module tests, Detekt, and ktlint pass on the final tree.
- Existing full 886-task validation and zero-finding code review on #194 remain applicable.

## Checklist

- [x] Changes are covered by the stacked test PRs.
- [x] No public API behavior or UI changed.
- [x] No release, deployment, or observability gate was enabled.
